### PR TITLE
Add: production環境のDBを設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.7.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '6.0.3.6'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+# gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -28,6 +28,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Set up for development and test environments
+  gem 'sqlite3', '~> 1.4'
 end
 
 group :development do
@@ -35,6 +37,10 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :production do
+  gem 'pg'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    pg (1.2.3)
     puma (4.3.10)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -150,6 +151,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)
+  pg
   puma (~> 4.1)
   rails (= 6.0.3.6)
   spring

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,6 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: 5 


### PR DESCRIPTION
## 関連するissue
- ref  #9 
- resolved #9 

## 概要
-  gem 'sqlite3'をコメントアウトする。
- 本番用DBにHerokuのPostgresを使用するため、本番環境にpgというgemをインストールする。
- config/database.ymlのproductionを編集して、本番用のDBにPostgresqlを指定する。
- herokuがインストールされているか確認する。
- herokuのバージョンを確認する。
- Railsアプリとherokuを紐づける。

## 確認事項
-  pg gemがインストールされている。
- config/database.ymlのproduction環境にPostgreSQLの設定が書かれている。

## 確認方法
1983c6847624855f6846cc685e11baf719eb60aa と 9cfc3d3a2db1c87a26017462255103fd44f49635 の差分ファイルで確認できます。

## 懸念点
herokuにpushできていない問題が発生しているので、別のissueとして切り出します。

## 参考記事
 特になし。
