### PR TITLE
Add: ジェネレートコマンドでルートとテストを生成しないように設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,12 @@ module RegexHunting
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    # Don't generate roots and test
+    config.generators do |g|
+      g.skip_routes true
+      g.test_framework false
+    end
+
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.


### PR DESCRIPTION
## 関連するissue
- ref  #27 
- resolved #27 

## 概要
rails gコマンドでルートとテストを生成しないように設定しました。
## 確認事項
-  modelとcontrollerのrails gコマンドを実行して、ルートとテストが生成されない。

## 確認方法
- modelとcontrollerのrails gコマンドを実行する。
```zsh
# モデル
bin/rails d model GameManagement 
```
```zsh
# コントローラ
bin/rails g controller GameManagements first finish
```
以下のような画面になれば、OKです。
- モデル
マイグレーションファイルとモデルファイルが生成されます。

[![Image from Gyazo](https://i.gyazo.com/dd11b83db9e1760e9fdfbf41f959e658.png)](https://gyazo.com/dd11b83db9e1760e9fdfbf41f959e658)
- コントローラ
コントローラファイルが生成されます。

[![Image from Gyazo](https://i.gyazo.com/a0837edf8216e411f4f3daa9819850fe.png)](https://gyazo.com/a0837edf8216e411f4f3daa9819850fe)
## 懸念点
特になし。

## 参考記事
 - [rails helper 基本](https://qiita.com/yukiyoshimura/items/f0763e187008aca46fb4)