### PR TITLE
Add: バックエンドのルーティングを定義

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,17 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get 'start', to: 'game_managements#start'
+      post 'finish', to: 'game_managements#finish'
+
+      resources :user, only: %i(create update) do
+        get 'my-page', to: 'my_pages#index'
+        get 'ranking', to: 'rankings#index'
+        get 'percent', to: 'percents#get_correct_percent'
+      end
+      post 'login', to: 'user_sessions#create'
+      delete 'logout', to: 'user_sessions#destroy'
+    end
+  end
 end


### PR DESCRIPTION
## 関連するissue
- ref  #30 
- resolved #30 

## 概要
以下を実行しました。
- routes.rbにnamespace :api とnamespace :v1 の名前空間を定義する。その名前空間内にルーティングを作成する。
- getメソッドを使って、game_managements#startのルーティングを作成する。
- postメソッドを使って、game_managements#finishのルーティングを作成する。
- resourcesを使って、users#create, users#updateのルーティングを作成する。
- postメソッドを使って、user_sessions#createのルーティングを作成する。
- deleteメソッドを使って、user_sessions#destroyのルーティングを作成する。
- getメソッドを使って、my_pages#indexのルーティングを作成する。
- getメソッドを使って、percents#get_correct_percentのルーティングを作成する。
- getメソッドを使って、Rankings#indexのルーティングを作成する。

## 確認事項
-  config/routes.rbにルートが定義されている。

## 確認方法
2669c3ea66751dc72b4623a2a18e411be7f1e210 の差分ファイルでルーティングを確認できます。

または、ブラウザで以下のURLを入力して、画像と同じルーティングが定義されていればOKです。
```zsh
http://localhost:3000/rails/info/routes
```
[![Image from Gyazo](https://i.gyazo.com/d7da0f5761b472c62eb46340d28ae86e.png)](https://gyazo.com/d7da0f5761b472c62eb46340d28ae86e)

## 懸念点
- OAuthのルーティングに関しては、OAuth着手時に実装する。
## 参考記事
- [【Rails】ルーティングの色々な作成方法をざっくりまとめてみた](https://zenn.dev/yukihaga/articles/69a816962ef6b9#5.%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E3%81%AE%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3)
