### PR TITLE
Add: Rails apiモードでsessionとcookieを使用できるようにする。

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
   before_action :require_login
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module RegexHunting
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/db/migrate/20211122134323_create_game_managements.rb
+++ b/db/migrate/20211122134323_create_game_managements.rb
@@ -3,7 +3,7 @@ class CreateGameManagements < ActiveRecord::Migration[6.0]
     create_table :game_managements do |t|
       t.integer :difficulty_level, null: false, default: 0
       t.integer :game_result, null: false, default: 0
-      t.datetime :result_time, null: false, default: 0
+      t.time :result_time, null: false, default: 0
       t.date :play_date, null: false
       t.references :user, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2021_11_28_072448) do
   create_table "game_managements", force: :cascade do |t|
     t.integer "difficulty_level", default: 0, null: false
     t.integer "game_result", default: 0, null: false
-    t.datetime "result_time", null: false
+    t.time "result_time", default: "2000-01-01 00:00:00", null: false
     t.date "play_date", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## 関連するissue
- ref  #38 
- resolved #38  

## 概要
Rails apiモードでsessionとcookieを使用するために、以下を実行しました。
- config/application.rbに以下のコードを追加する。
```
class Application < Rails::Application
  # ...
  config.api_only = true

  # この2行を追加する
  config.middleware.use ActionDispatch::Cookies
  config.middleware.use ActionDispatch::Session::CookieStore
end
```
- app/controllers/application_controller.rb を開いて ActionController::Cookies をインクルードします。
## 確認事項
-  差分ファイルに正しいコードが存在するか。

## 確認方法
d5cab392d7b47c236ab6f12d6a4b0dc9ad6a8364 と 8a193ec7a68b5d1226e1af55b60de7f2e33a6576 の差分ファイルで確認できます。

## 懸念点
フロントでどうやって使うかは未定です。

## 参考記事
 - [Rails の API モードでセッションやクッキーを使えるようにする](https://www.nightswinger.dev/2020/04/rails-api-with-session-and-cookie/)

