### PR TITLE
Add: CSRF対策とCORSを実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.6)
@@ -247,6 +249,7 @@ DEPENDENCIES
   pg
   pry-byebug
   puma (~> 4.1)
+  rack-cors
   rails (= 6.0.3.6)
   rails_best_practices
   rubocop

--- a/app/controllers/api/v1/account_settings_controller.rb
+++ b/app/controllers/api/v1/account_settings_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::AccountSettingsController < ApplicationController
+  after_action :set_csrf_token_header, only: :update
+
   def update
     if current_user.update(user_params)
       render json: {

--- a/app/controllers/api/v1/game_managements_controller.rb
+++ b/app/controllers/api/v1/game_managements_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::GameManagementsController < ApplicationController
   MIN_TIMES = 10
+  skip_before_action :verify_authenticity_token, only: :start
+  after_action :set_csrf_token_header, only: :start
 
   def start
     # ゲームに関する処理

--- a/app/controllers/api/v1/my_pages_controller.rb
+++ b/app/controllers/api/v1/my_pages_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::MyPagesController < ApplicationController
+  after_action :set_csrf_token_header, only: :index
+
   def index
     # 今日を含めた1ヶ月分の各日における初級, 中級, 上級ゲーム頻度に関する処理
     # デフォルトで1ヶ月にする

--- a/app/controllers/api/v1/password_resets_controller.rb
+++ b/app/controllers/api/v1/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class Api::V1::PasswordResetsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+  after_action :set_csrf_token_header, only: %i(create edit update)
+
   def create
     user = User.find_by(email: params[:email])
     user&.deliver_reset_password_instructions!

--- a/app/controllers/api/v1/percents_controller.rb
+++ b/app/controllers/api/v1/percents_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PercentsController < ApplicationController
+  after_action :set_csrf_token_header, only: :get_correct_percents
+
   def get_correct_percents
     # 検索期間が決定したら、このアクションが呼び出される
     # 検索期間に応じた初級, 中級, 上級のゲーム管理データを取得

--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::RankingsController < ApplicationController
   before_action :set_each_difficulty_level_top_three, only: :index
+  after_action :set_csrf_token_header, only: :index
+
 
   # 自分のランクを表示する部分は一旦保留。かなりムズイ
   def index

--- a/app/controllers/api/v1/title_settings_controller.rb
+++ b/app/controllers/api/v1/title_settings_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::TitleSettingsController < ApplicationController
+  after_action :set_csrf_token_header, only: :update
+
   def update
     if current_user.update(active_title: params[:user][:select_title])
       render json: {

--- a/app/controllers/api/v1/user_sessions_controller.rb
+++ b/app/controllers/api/v1/user_sessions_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::UserSessionsController < ApplicationController
   skip_before_action :require_login, only: :create
+  skip_before_action :verify_authenticity_token, only: :create
+  after_action :set_csrf_token_header, only: :create
 
   def create
     user = login(params[:email], params[:password])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,9 @@
 class Api::V1::UsersController < ApplicationController
   skip_before_action :require_login, only: :create
+  skip_before_action :verify_authenticity_token, only: :create
+  after_action :set_csrf_token_header, only: :create
 
   def create
-    binding.pry
     user = User.new(user_params)
     if user.save
       render json: {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::API
+  include ActionController::RequestForgeryProtection
   include ActionController::Cookies
+  protect_from_forgery with: :exception
   before_action :require_login
 
   private
@@ -8,5 +10,10 @@ class ApplicationController < ActionController::API
     render json: {
       alert: "Please login first"
     }, status: :forbidden
+  end
+
+  # form_authenticity_tokenは、CSRF Tokenを生成するメソッド
+  def set_csrf_token_header
+    response.set_header('X-CSRF-Token', form_authenticity_token)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module RegexHunting
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Disable cross-origin validation.
+    config.action_controller.forgery_protection_origin_check = false
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:3001'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
+      expose: ['X-CSRF-Token'],
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,9 @@
+if Rails.env == 'production'
+  Rails.application.config.session_store :cookie_store, key: '_regex_hunting_session',
+                                                        domain: '.regex-hunting.com',
+                                                        same_site: :none,
+                                                        secure: true
+else
+  Rails.application.config.session_store :cookie_store, key: '_regex_hunting_session'
+end
+

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -226,7 +226,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.line.bot_prompt = "normal"
   # config.line.user_info_mapping = {name: 'displayName'}
 
-  
+
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2
   # config.discord.key = "xxxxxx"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
       resources :users, only: :create do
         get 'my-page', to: 'my_pages#index'
         get 'percent', to: 'percents#get_correct_percents'
-        get 'account-settings', to: 'account_settings#update'
-        get 'title-settings', to: 'title_settings#update'
+        patch 'account-settings', to: 'account_settings#update'
+        patch 'title-settings', to: 'title_settings#update'
       end
       get 'ranking', to: 'rankings#index'
       post 'login', to: 'user_sessions#create'


### PR DESCRIPTION
## 関連するissue
- ref   #39 
- resolved #39

## 概要
以下を実行しました。
- gem 'rack-cors'をインストールする。
- config/initializers/cors.rbのコメントアウトを全て外す。
- config/initializers/cors.rbのoriginsとresource以下 を設定する。
- application_controller.rb に include ActionController::RequestForgeryProtection を追加する。
- set_csrf_token_headerというCSRFトークンを生成するメソッドを作成する。
- config/application.rbにconfig.action_controller.forgery_protection_origin_check = falseを追加する。
- config/initializers/cors.rbにexposeを設定する。
- config/initializers/session_store.rbでSameSite を None 、Secure を True にする
- コントローラにcsrfトークンを設定する。
## 確認事項
-  差分ファイルで正しいコードが書かれていることを確認できる。

## 確認方法
以下のコミットの差分ファイルで確認できます。

## 懸念点
- 実際にHTTPリクエストを出したりしていないので、トークンが本当に付与されるか不明です。
- トークン検証時にエラーが起こるかもしれません。
## 参考記事
 - [【Rails API】CSRF 対策をあきらめないでちゃんとやる2021](https://midorimici.com/posts/rails-api-csrf#csrf-token-%E3%81%AE%E8%A8%AD%E5%AE%9A)
 - [【Rails】SameSiteとSecure属性の付与〜Railsのセキュリティ対策〜](https://qiita.com/nakanishi03/items/dee8ae104635b2d1aff0)
 - [Railsアプリで実際にあった5つのセキュリティ問題と修正方法（翻訳）](https://techracho.bpsinc.jp/hachi8833/2021_10_28/62858)
 - [Rails API + SPAのCSRF対策例](https://zenn.dev/leaner_tech/articles/20210930-rails-api-spa-csrf)
 - [Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#Login_CSRF)
 - [RailsのCSRF保護を詳しく調べてみた（翻訳）](https://techracho.bpsinc.jp/hachi8833/2017_10_23/46891)
 - [Rails5系以上でInvalidAuthenticityTokenエラー](https://qiita.com/munaita_/items/e1d36fac9515654a76de)
 - [session_keyの名前を見つける方法](https://lilac-xi.hatenablog.com/entry/2018/12/02/032124)
 - [Railsでサブドメイン間でログインを保持するためのセッション設定](https://moto.hatenadiary.com/entry/subdomain-keep-session)
 - [railsでサブドメイン間のcookieを共有する方法](https://hivecolor.com/id/117)
 - [SPA+SSR+APIで構成したWebアプリケーションのセッション管理
](https://tech.pepabo.com/2020/09/23/session-management-for-web-apps-using-spa-ssr-api/)
- [Railsのルーティングを極める(前編)](https://techracho.bpsinc.jp/baba/2020_11_18/15665)
- [【Rails API + SPA】ログイン方法とCSRF対策例](https://qiita.com/k_kind/items/e26f03f4e24551b46b98#csrf%E3%81%A8cookie)
- [Rails5のapplication_contorollerに書いてあるprotect_from_forgery with: :exceptionとはなんぞや
](https://mocha0426.hatenablog.com/entry/2018/03/25/161940)
- [React + Rails(API)で tokenを用いたCSRF対策の基礎(のメモ)](https://kappaz.hatenablog.com/entry/2020/08/17/141127)
