### PR TITLE
Add: APIリクエストに関する定数とスタイルに関する定数を定義

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,11 @@
+// REQUEST_STATEは、APIリクエスト中に画面がいまどういう状態なのか？を知るための定数
+export const REQUEST_STATE = {
+  INITIAL: 'INITIAL',
+  LOADING: 'LOADING',
+  OK: 'OK',
+}
+
+// クライアント側のエラーを表す定数
+export const HTTP_STATUS_CODE = {
+  NOT_ACCEPTABLE: 406,
+}

--- a/frontend/src/style_constants.js
+++ b/frontend/src/style_constants.js
@@ -1,0 +1,15 @@
+// 色を決める際に、定義定義する。
+export const COLORS = {
+  MAIN: '#618A12',
+  SUB: '#F6F6DC'
+  BORDER: '#e2e2e2',
+  SUB_TEXT: '#545454',
+  FONT_STROKE: '#030002',
+  RED: 'FF6347',
+  BLUE: '0066B3'
+}
+
+// フォントサイズを決める際に、適宜定義する。
+export const FONT_SIZE = {
+  HEADER_TITLE: '36px'
+}


### PR DESCRIPTION
## 関連するissue
- ref  #47 
- resolved #47  

## 概要
以下を実行しました。
- frontディレクトリで、touch src/{constants.js,style_constants.js}を実行する。
- constants.jsに、APIリクエストに関する定数を定義する。
- style_constants.jsに、スタイルに関する定数を定義します。 

## 確認事項
-  APIリクエストに関する定数がsrc/constants.jsに定義されている。
-  スタイルに関する定数がsrc/style_constants.jsに定義されている。

## 確認方法
ed3c46a9291a50e04a9e36ee467380517a19a42f の差分ファイルで確認できます。

## 懸念点
別の定数が必要になり次第、定数を適宜追加していきます。

## 参考記事
特になし。
