### PR TITLE
Add: APIコールに関するURL文字列と、ログイン関係と新規会員登録のAPIコール関数を定義

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "axios": "^0.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.0.2",

--- a/frontend/src/apis/login.js
+++ b/frontend/src/apis/login.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { userSessionsCreate, userSessionsDestroy } from '../urls/index';
+
+// ログインするためのAPIコール関数
+export const postUserSession = async (params) => {
+  try {
+    const response = await axios.post(userSessionsCreate,
+      {
+        email: params.user.email,
+        password: params.user.password
+      }
+    );
+    return response.data;
+  } catch(e) {
+    throw e;
+  }
+};
+
+// ログアウトするためのAPIコール関数
+export const deleteUserSession = async (params) => {
+  try {
+    const response = await axios.delete(userSessionsDestroy);
+    return response.data;
+  } catch(e) {
+    throw e;
+  }
+};

--- a/frontend/src/apis/signup.js
+++ b/frontend/src/apis/signup.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { usersCreate } from '../urls/index';
+
+// ログインするためのAPIコール関数
+export const postUser = async (params) => {
+  try {
+    const response = await axios.post(userCreate,
+      {
+        name: params.user.name
+        email: params.user.email,
+        password: params.user.password,
+        password_confirmation: params.user.password_confirmation
+      }
+    );
+    return response.data;
+  } catch(e) {
+    throw e;
+  }
+};

--- a/frontend/src/containers/LandingPages.jsx
+++ b/frontend/src/containers/LandingPages.jsx
@@ -1,6 +1,25 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 
-export const LandingPages = () => {
+// ログイン関係のAPIコール関数
+import { postUserSession, } from '../apis/login'; 
+// deleteUserSession 
+
+export const LandingPages = () => { 
+
+  // ユーザーをログインさせる。
+  useEffect(() => {
+    postUserSession({
+      user: {
+        email: 'glen@stroman.com',
+        password: '3150test' 
+      }
+    })
+    .then((data) => {
+      console.log(data);
+      console.log("ログインが成功した");
+    })
+  }, []);
+
   return (
     <>
       LPページ

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -2,7 +2,7 @@ const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/v1';
 
 // ゲーム関係
 export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/start`;
-export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/finish`;
+export const gameManagementsFinish = `${DEFAULT_API_LOCALHOST}/finish`;
 
 // 会員登録
 export const usersCreate = `${DEFAULT_API_LOCALHOST}/users`;
@@ -16,13 +16,13 @@ export const rankings = `${DEFAULT_API_LOCALHOST}/ranking`;
 
 // ユーザー関係
 export const myPages = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/my-page`;
+  `${DEFAULT_API_LOCALHOST}/users/${user_id}/my-page`;
 export const percents = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/percent`;
+  `${DEFAULT_API_LOCALHOST}/users/${user_id}/percent`;
 export const accountSettings = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/account-settings`;
+  `${DEFAULT_API_LOCALHOST}/users/${user_id}/account-settings`;
 export const titleSettings = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/title-settings`;
+  `${DEFAULT_API_LOCALHOST}/users/${user_id}/title-settings`;
 
 // パスワードリセット関係
 export const passwordResetsCreate = `${DEFAULT_API_LOCALHOST}/password_resets`;

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -1,0 +1,32 @@
+const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/v1'
+
+// ゲーム関係
+export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/start`
+export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/finish`
+
+// 会員登録
+export const users = `${DEFAULT_API_LOCALHOST}/users`
+
+// ログイン関係
+export const userSessionsCreate = `${DEFAULT_API_LOCALHOST}/login`
+export const userSessionsCreate = `${DEFAULT_API_LOCALHOST}/logout`
+
+// ランキング
+export const rankings = `${DEFAULT_API_LOCALHOST}/ranking`
+
+// ユーザー関係
+export const myPages = (user_id) => 
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/my-page`
+export const percents = (user_id) => 
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/percent`
+export const accountSettings = (user_id) => 
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/account-settings`
+export const titleSettings = (user_id) => 
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/title-settings`
+
+// パスワードリセット関係
+export const passwordResetsCreate = `${DEFAULT_API_LOCALHOST}/password_resets`
+export const passwordResetsEdit = (id) => 
+  `${DEFAULT_API_LOCALHOST}/password_resets/${id}/edit`
+export const passwordResetsUpdate = (id) => 
+  `${DEFAULT_API_LOCALHOST}/password_resets/${id}`

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -1,32 +1,32 @@
-const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/v1'
+const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/v1';
 
 // ゲーム関係
-export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/start`
-export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/finish`
+export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/start`;
+export const gameManagementsStart = `${DEFAULT_API_LOCALHOST}/finish`;
 
 // 会員登録
-export const users = `${DEFAULT_API_LOCALHOST}/users`
+export const usersCreate = `${DEFAULT_API_LOCALHOST}/users`;
 
 // ログイン関係
-export const userSessionsCreate = `${DEFAULT_API_LOCALHOST}/login`
-export const userSessionsCreate = `${DEFAULT_API_LOCALHOST}/logout`
+export const userSessionsCreate = `${DEFAULT_API_LOCALHOST}/login`;
+export const userSessionsDestroy = `${DEFAULT_API_LOCALHOST}/logout`;
 
 // ランキング
-export const rankings = `${DEFAULT_API_LOCALHOST}/ranking`
+export const rankings = `${DEFAULT_API_LOCALHOST}/ranking`;
 
 // ユーザー関係
 export const myPages = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/my-page`
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/my-page`;
 export const percents = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/percent`
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/percent`;
 export const accountSettings = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/account-settings`
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/account-settings`;
 export const titleSettings = (user_id) => 
-  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/title-settings`
+  `${DEFAULT_API_LOCALHOST}/users/${user_Id}/title-settings`;
 
 // パスワードリセット関係
-export const passwordResetsCreate = `${DEFAULT_API_LOCALHOST}/password_resets`
+export const passwordResetsCreate = `${DEFAULT_API_LOCALHOST}/password_resets`;
 export const passwordResetsEdit = (id) => 
-  `${DEFAULT_API_LOCALHOST}/password_resets/${id}/edit`
+  `${DEFAULT_API_LOCALHOST}/password_resets/${id}/edit`;
 export const passwordResetsUpdate = (id) => 
-  `${DEFAULT_API_LOCALHOST}/password_resets/${id}`
+  `${DEFAULT_API_LOCALHOST}/password_resets/${id}`;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2768,6 +2768,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.2.tgz#7cf783331320098bfbef620df3b3c770147bc224"
   integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5342,6 +5349,11 @@ follow-redirects@^1.0.0:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
   integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+
+follow-redirects@^1.14.4:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 関連するissue
- ref  #49 
- resolved #49 
## 概要
以下を実行しました。
- mkdir src/urlsで、「URL文字列が定義されたファイル」を配置するディレクトリを作成する。
- touch src/urls/index.jsで、「URL文字列を定数として定義するファイル」を作成する。
- src/urls/index.jsに、APIコントローラを呼び出すURL文字列を定義する。
-  yarnでaxiosをインストールする。
- mkdir src/apisで、新しいディレクトリを作成します。
- touch src/apis/login.jsで、APIを呼び出す関数を定義するファイルを作成する。
- src/apis/login.js内に、UserSessions#createアクションを呼び出す関数を作成する。
- src/apis/login.js内に、UserSessions#destroyアクションを呼び出す関数を作成する。
- touch src/apis/signup.jsで、APIを呼び出す関数を定義するファイルを作成する。
- src/apis/signup.jsに、Users#createアクションを呼び出す関数を作成する。

## 確認事項
- src/urls/index.js配下に、APIコントローラを呼び出すURL文字列が定義されている。
- src/apis/login.js配下に、APIを呼び出す関数(postUserSession, deleteUserSession)が定義されている。
- src/apis/signup.js配下に、APIを呼び出す関数(postUser)が定義されている。

## 確認方法
差分ファイルから確認できます。

## 懸念点
postUserSessionを実行した時、paramsにuser_sessionという謎のキーが存在しました。こいつがなぜ存在しているか分からないので、いずれ何かに影響が出るかもしれません。ちなみに、postUserSessionの第2引数を空のオブジェクトにした場合、user_sessionも空のオブジェクトでした。
- postUserSession
```ruby
// ログインするためのAPIコール関数
export const postUserSession = async (params) => {
  try {
    const response = await axios.post(userSessionsCreate,
      {
        email: params.user.email,
        password: params.user.password
      }
    );
    return response.data;
  } catch(e) {
    throw e;
  }
};
```

- postUserSessionを実行した時に、サーバ側に渡されるparams
```ruby
[1] pry(#<Api::V1::UserSessionsController>)> params
=> <ActionController::Parameters {"email"=>"glen@stroman.com", "password"=>"3150test", "controller"=>"api/v1/user_sessions", "action"=>"create", "user_session"=>{"email"=>"glen@stroman.com", "password"=>"3150test"}} permitted: false>
```

## 参考記事
特になし
