### PR TITLE
Fix: ログインした後に、ログアウトせずにLPページにいくとログイン状態を保持できない問題を解決

### DIFF
--- a/frontend/src/containers/LandingPages.jsx
+++ b/frontend/src/containers/LandingPages.jsx
@@ -82,13 +82,15 @@ export const LandingPages = () => {
 
   // useContext
   const {
-    requestUserState, 
+    requestUserState: { userState }, 
     dispatch, 
     requestUserActionTyps
   } = useContext(UserContext);
 
+  // 初めてLPページに訪れた場合、ログインしていないので、
+  // 2回目のdispatchのdata.sessionはfalseとなる
   useEffect(() => {
-    if(requestUserState.userState.session === true){
+    if(userState.session === false){
       dispatch({ type: requestUserActionTyps.REQUEST });
       checkLoginStatus().then((data) => {
         dispatch({
@@ -113,7 +115,7 @@ export const LandingPages = () => {
     }
   }, [
     dispatch, 
-    requestUserState.userState.session,
+    userState.session,
     requestUserActionTyps.REQUEST, 
     requestUserActionTyps.REQUEST_SUCCESS,
     requestUserActionTyps.REQUEST_FAILURE


### PR DESCRIPTION
## 関連するissue
特になし。

## 概要
以下を実行しました。
LPページのuseEffectの条件分岐を変更 

## 確認事項
- ログインした後に、LPページに行ってもログイン状態を保持できる。

## 確認方法
- ログインモーダルから確認できます。

## 懸念点
特になし。

## 参考記事
特になし。