### PR TITLE
Add: ゲーム画面を作成した

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -61,7 +61,7 @@ function App() {
 
             {/* ゲームページ */}
             <Route
-              exact path="/games/:difficulty_level/start"
+              exact path="/games/:difficulty/start"
               element={<Games />}
             />
 

--- a/frontend/src/components/Buttons/StartButton.jsx
+++ b/frontend/src/components/Buttons/StartButton.jsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react'; 
 import styled from 'styled-components';
 
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+// Button
 import { RedRoundButton } from '../shared_style';
 
 const StartButtonWrapper = styled(RedRoundButton)`
@@ -12,7 +16,7 @@ const StartButtonWrapper = styled(RedRoundButton)`
 const StartButtonTextWrapper = styled.div`
   width: 230px;
   height: 58px;
-  color: white;
+  color: ${COLORS.SUB};
   font-family: YuGothic;
   font-style: normal;
   font-size: 36px;

--- a/frontend/src/components/Footers/Footer.jsx
+++ b/frontend/src/components/Footers/Footer.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 
 // Colors
-import { COLORS } from '../style_constants.js';
+import { COLORS } from '../../style_constants.js';
 
 // BaseLink
-import { BaseLink } from './shared_style.js';
+import { BaseLink } from '../shared_style.js';
 
 const FooterWrapper = styled.div`
   height: 55px;

--- a/frontend/src/components/Footers/GameFooter.jsx
+++ b/frontend/src/components/Footers/GameFooter.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+// BaseLink
+import { FakeLink } from '../shared_style.js';
+
+const FooterWrapper = styled.div`
+  height: 55px;
+  display: flex;
+  justify-content: start;
+  background-color: ${COLORS.BROWN};
+  width: 100%;
+`;
+
+const FooterNav = styled.nav`
+  margin-left: 20px;
+`;
+
+const FooterNavFakeLink = styled(FakeLink)`
+  height: 52px;
+  line-height: 52px;
+  display: inline-block;
+  color: ${COLORS.SUB};
+  margin-left: 20px; 
+  :hover {
+    opacity: 0.7;
+    border-bottom: solid ${COLORS.SUB};
+  }
+`;
+
+
+export const GameFooter = () => {
+  return (
+    <>
+      <FooterWrapper>
+        <FooterNav>
+          <FooterNavFakeLink>
+            スライドを見る
+          </FooterNavFakeLink>
+        </FooterNav>
+      </FooterWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/AdvancedMonster.jsx
+++ b/frontend/src/components/Games/AdvancedMonster.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+import AdvancedMonsterImage from '../../images/intermediate.png'; 
+
+const AdvancedWrapper = styled.div`
+`;
+
+const AdvancedMonsterWrapper = styled.img`
+  width: 600px;
+  height: 400px;
+  object-fit: contain;
+`;
+
+const HpGageWrapper = styled.div`
+  width: 600px;
+  height: 15px;
+  border: 1px solid ${COLORS.GAGE_GRAY};
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: ${COLORS.LIGHT_BLUE};
+`;
+
+export const AdvancedMonster = () => {
+  return (
+    <>
+      <AdvancedWrapper>
+        <AdvancedMonsterWrapper src={AdvancedMonsterImage} />
+        <HpGageWrapper />
+      </AdvancedWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+const CodeBlockWrapper = styled.div`
+  background-color: ${COLORS.LIGHT_BLACK};
+  border-radius: 3px;
+  width: 860px;
+  height: 53px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const AnchorWrapper = styled.div`
+  height: 53px;
+  font-size: 23px;
+  line-height: 53px;
+  color: ${COLORS.WHITE};
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+  margin-left: 10px;
+  margin-right: 10px;
+`;
+
+const CodeBlockTextWrapper = styled.div`
+  height: 53px;
+  font-size: 23px;
+  line-height: 53px;
+  color: ${COLORS.WHITE};
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+`;
+
+export const CodeBlock = () => {
+  return (
+    <>
+      <CodeBlockWrapper>
+        <AnchorWrapper>
+          /
+        </AnchorWrapper>
+        <CodeBlockTextWrapper>
+         
+        </CodeBlockTextWrapper>
+        <AnchorWrapper>
+          /g
+        </AnchorWrapper>
+      </CodeBlockWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 
 // Colors
@@ -37,6 +37,28 @@ const CodeBlockTextWrapper = styled.div`
 `;
 
 export const CodeBlock = () => {
+
+  const [state, setState] = useState("");
+
+  const keyFunction = useCallback((e) => {
+    setState( prevState => {
+      const newState = prevState + e.key; 
+      return newState;
+    } );
+  }, []);
+
+  // useEffectの第一引数の副作用関数は、コンポーネントの初回レンダリング時、
+  // および、keyFunctionが変化したときに実行される
+  // クリーンアップ関数はコンポーネントがアンマウント, 副作用関数が再実行
+  // された時に実行される。クリーンアップ関数を副作用関数の戻り値として返すことで、
+  // コンポーネントがレンダリングされるたびにイベントの登録が重複するのを防ぐことができる
+  useEffect(() => {
+    document.addEventListener("keydown", keyFunction, false);
+    return () => {
+      document.removeEventListener("keydown", keyFunction, false);
+    }
+  }, [keyFunction]);
+
   return (
     <>
       <CodeBlockWrapper>
@@ -44,7 +66,7 @@ export const CodeBlock = () => {
           /
         </AnchorWrapper>
         <CodeBlockTextWrapper>
-         
+          {state} 
         </CodeBlockTextWrapper>
         <AnchorWrapper>
           /g

--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -22,8 +22,8 @@ const AnchorWrapper = styled.div`
   font-family: YuGothic;
   font-style: normal;
   font-weight: 500;
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: 15px;
+  margin-right: 15px;
 `;
 
 const CodeBlockTextWrapper = styled.div`

--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 // Colors
@@ -26,6 +26,7 @@ const AnchorWrapper = styled.div`
   margin-right: 15px;
 `;
 
+/*
 const CodeBlockTextWrapper = styled.div`
   height: 53px;
   font-size: 23px;
@@ -35,29 +36,34 @@ const CodeBlockTextWrapper = styled.div`
   font-style: normal;
   font-weight: 500;
 `;
+*/
+
+const CodeBlockInput = styled.input`
+  height: 51px;
+  width: 700px;
+  font-size: 23px;
+  line-height: 51px;
+  background-color: ${COLORS.LIGHT_BLACK};
+  color: ${COLORS.WHITE};
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+  outline: none;
+  border: none;
+  text-align: center;
+`;
 
 export const CodeBlock = () => {
 
   const [state, setState] = useState("");
 
-  const keyFunction = useCallback((e) => {
-    setState( prevState => {
-      const newState = prevState + e.key; 
-      return newState;
-    } );
-  }, []);
+  const handleInput = (e) => {
+    setState(e.target.value);
+  }
 
-  // useEffectの第一引数の副作用関数は、コンポーネントの初回レンダリング時、
-  // および、keyFunctionが変化したときに実行される
-  // クリーンアップ関数はコンポーネントがアンマウント, 副作用関数が再実行
-  // された時に実行される。クリーンアップ関数を副作用関数の戻り値として返すことで、
-  // コンポーネントがレンダリングされるたびにイベントの登録が重複するのを防ぐことができる
   useEffect(() => {
-    document.addEventListener("keydown", keyFunction, false);
-    return () => {
-      document.removeEventListener("keydown", keyFunction, false);
-    }
-  }, [keyFunction]);
+    document.getElementById('code-block').focus();
+  }, []);
 
   return (
     <>
@@ -65,9 +71,12 @@ export const CodeBlock = () => {
         <AnchorWrapper>
           /
         </AnchorWrapper>
-        <CodeBlockTextWrapper>
-          {state} 
-        </CodeBlockTextWrapper>
+        <CodeBlockInput 
+          type='text' 
+          id='code-block' 
+          value={state} 
+          onChange={(e) => handleInput(e)} 
+        />
         <AnchorWrapper>
           /g
         </AnchorWrapper>

--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -26,18 +26,6 @@ const AnchorWrapper = styled.div`
   margin-right: 15px;
 `;
 
-/*
-const CodeBlockTextWrapper = styled.div`
-  height: 53px;
-  font-size: 23px;
-  line-height: 53px;
-  color: ${COLORS.WHITE};
-  font-family: YuGothic;
-  font-style: normal;
-  font-weight: 500;
-`;
-*/
-
 const CodeBlockInput = styled.input`
   height: 51px;
   width: 700px;

--- a/frontend/src/components/Games/ElementaryMonster.jsx
+++ b/frontend/src/components/Games/ElementaryMonster.jsx
@@ -18,7 +18,7 @@ const ElementaryMonsterWrapper = styled.img`
 const HpGageWrapper = styled.div`
   width: 160px;
   height: 15px;
-  border: 1px solid ${COLORS.SUB};
+  border: 1px solid ${COLORS.GAGE_GRAY};
   box-sizing: border-box;
   border-radius: 3px;
   background-color: ${COLORS.LIGHT_BLUE};

--- a/frontend/src/components/Games/ElementaryMonster.jsx
+++ b/frontend/src/components/Games/ElementaryMonster.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+import ElementaryMonsterImage from '../../images/elementary.png'; 
+
+const ElementaryWrapper = styled.div`
+`;
+
+const ElementaryMonsterWrapper = styled.img`
+  width: 211px;
+  height: 205px;
+  object-fit: contain;
+`;
+
+const HpGageWrapper = styled.div`
+  width: 160px;
+  height: 15px;
+  border: 1px solid ${COLORS.SUB};
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: ${COLORS.LIGHT_BLUE};
+`;
+
+export const ElementaryMonster = () => {
+  return (
+    <>
+      <ElementaryWrapper>
+        <ElementaryMonsterWrapper src={ElementaryMonsterImage} />
+        <HpGageWrapper />
+      </ElementaryWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/HpGage.jsx
+++ b/frontend/src/components/Games/HpGage.jsx
@@ -19,7 +19,7 @@ const HpGageWrapper = styled.div`
 
 const TypeWrapper = styled.div`
   height: 26px;
-  width: 77px;
+  width: 120px;
   font-size: 18px;
   line-height: 26px;
   background-color: ${COLORS.GAGE_GRAY};

--- a/frontend/src/components/Games/HpGage.jsx
+++ b/frontend/src/components/Games/HpGage.jsx
@@ -4,14 +4,16 @@ import styled from 'styled-components';
 // Colors
 import { COLORS } from '../../style_constants.js';
 
-const TimeGageWrapper = styled.div`
+const HpGageWrapper = styled.div`
   background-color: ${COLORS.LIGHT_BLACK};
-  border-radius: 3px 3px 0 0;
+  border-radius: 0 0 3px 3px;
   width: 100%;
-  height: 36px;
+  height: 31px;
   display: flex;
   box-sizing: border-box;
-  border: 5px solid;
+  border-left: 5px solid;
+  border-right: 5px solid;
+  border-bottom: 5px solid;
   border-color: ${COLORS.GAGE_GRAY};
 `;
 
@@ -29,23 +31,23 @@ const TypeWrapper = styled.div`
 
 const GageWrapper = styled.div`
   height: 100%;
-  width: 60%;
-  background-color: ${COLORS.YELLOW};
+  width: 80%;
+  background-color: ${COLORS.LIGHT_BLUE};
   box-sizing: border-box;
   border: none;
   outline: none;
 `;
 
-export const TimeGage = () => {
+export const HpGage = () => {
   return (
     <>
-      <TimeGageWrapper>
+      <HpGageWrapper>
         <TypeWrapper>
-          TIME
+          HP
         </TypeWrapper>
         <GageWrapper>
         </GageWrapper>
-      </TimeGageWrapper>
+      </HpGageWrapper>
     </>
   );
 };

--- a/frontend/src/components/Games/IntermediateMonster.jsx
+++ b/frontend/src/components/Games/IntermediateMonster.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+import IntermediateMonsterImage from '../../images/intermediate.png'; 
+
+const IntermediateWrapper = styled.div`
+`;
+
+const IntermediateMonsterWrapper = styled.img`
+  width: 600px;
+  height: 400px;
+  object-fit: contain;
+`;
+
+const HpGageWrapper = styled.div`
+  width: 600px;
+  height: 15px;
+  border: 1px solid ${COLORS.GAGE_GRAY};
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: ${COLORS.LIGHT_BLUE};
+`;
+
+export const IntermediateMonster = () => {
+  return (
+    <>
+      <IntermediateWrapper>
+        <IntermediateMonsterWrapper src={IntermediateMonsterImage} />
+        <HpGageWrapper />
+      </IntermediateWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/MetaMenuBar.jsx
+++ b/frontend/src/components/Games/MetaMenuBar.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+const MetaMenuBarWrapper = styled.div`
+  background-color: ${COLORS.SUB};
+  border-radius: 3px;
+  height: 490px;
+  width: 220px;
+  outline: 8px solid ${COLORS.GRAY};
+  display: inline-block;
+`;
+
+const TitleWrapper = styled.div`
+
+`;
+
+const MetaContentWrapper = styled.div`
+
+`;
+
+export const MetaMenuBar = () => {
+  return (
+    <>
+      <MetaMenuBarWrapper>
+        <TitleWrapper>
+          メタ文字一覧
+        </TitleWrapper>
+        <MetaContentWrapper>
+        </MetaContentWrapper>
+      </MetaMenuBarWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/MetaMenuBar.jsx
+++ b/frontend/src/components/Games/MetaMenuBar.jsx
@@ -14,7 +14,13 @@ const MetaMenuBarWrapper = styled.div`
 `;
 
 const TitleWrapper = styled.div`
-
+  height: 60px;
+  font-size: 21px;
+  line-height: 60px;
+  color: ${COLORS.BLACK};
+  font-family: YuGothic;
+  font-weight: normal;
+  text-align: center;
 `;
 
 const MetaContentWrapper = styled.div`
@@ -29,6 +35,128 @@ export const MetaMenuBar = () => {
           メタ文字一覧
         </TitleWrapper>
         <MetaContentWrapper>
+          <table>
+            <tr>
+              <th>メタ文字</th> <th>意味</th>
+            </tr>
+            <tr>
+              <td>\d</td> <td>1桁の数字</td>
+            </tr>
+            <tr>
+              <td>[0-9]</td> <td>1桁の数字</td>
+            </tr>
+            <tr>
+              <td>\d+</td> <td>1桁以上の数字</td>
+            </tr>
+            <tr>
+              <td>{'{'}n,m}</td> <td>直前の文字がn個以上、m個以下</td>
+            </tr>
+            <tr>
+              <td>{'{'}n}</td> <td>直前の文字がちょうどn個</td>
+            </tr>
+            <tr>
+              <td>{'{'}n,}</td> <td>直前の文字がn個以下</td>
+            </tr>
+            <tr>
+              <td>{'{'},n}</td> <td>直前の文字がn個以下</td>
+            </tr>
+            <tr>
+              <td>[AB]</td> <td>A, Bのいずれか1文字(A, Bは任意の1文字)</td>
+            </tr>
+            <tr>
+              <td>[ABC]</td> <td>A, B, Cのいずれか1文字(A, B, Cは任意の1文字)</td>
+            </tr>
+            <tr>
+              <td>[a-z]</td> <td>小文字アルファベットのいずれか1文字</td>
+            </tr>
+            <tr>
+              <td>?</td> <td>直前の文字が1文字または無し</td>
+            </tr>
+            <tr>
+              <td>(2文字以上の文字列)?</td> <td>直前の文字が2文字以上の文字列または無し</td>
+            </tr>
+            <tr>
+              <td>.</td> <td>任意の1文字</td>
+            </tr>
+            <tr>
+              <td>\n</td> <td>改行</td>
+            </tr>
+            <tr>
+              <td>+</td> <td>直前の文字が1文字以上</td>
+            </tr>
+            <tr>
+              <td>*</td> <td>直前の文字が0文字以上</td>
+            </tr>
+            <tr>
+              <td>.+</td> <td>任意の文字が1文字以上(貪欲なマッチ)</td>
+            </tr>
+            <tr>
+              <td>.*</td> <td>任意の文字が0文字以上(貪欲なマッチ)</td>
+            </tr>
+            <tr>
+              <td>[^A]*</td> <td>A以外の任意の文字が0文字以上</td>
+            </tr>
+            <tr>
+              <td>.+?</td> <td>任意の文字が1文字以上(控えめなマッチ)</td>
+            </tr>
+            <tr>
+              <td>.*?</td> <td>任意の文字が0文字以上(控えめなマッチ)</td>
+            </tr>
+            <tr>
+              <td>()</td> <td>()内をキャプチャする。</td>
+            </tr>
+            <tr>
+              <td>(?{"<"}name>pattern)</td> <td>名前付きキャプチャ(nameはキャプチャ名)</td>
+            </tr>
+            <tr>
+              <td>\k{"<"}name></td> <td>名前付きキャプチャで取得した文字列</td>
+            </tr>
+            <tr>
+              <td>(?:)</td> <td>()と?:を合わせると、キャプチャをしなくなる。</td>
+            </tr>
+            <tr>
+              <td>\w</td> <td>[a-zA-Z0-9_]</td>
+            </tr>
+            <tr>
+              <td>^</td> <td>行頭を表す。</td>
+            </tr>
+            <tr>
+              <td>$</td> <td>行末を表す。</td>
+            </tr>
+            <tr>
+              <td>\t</td> <td>タブ文字</td>
+            </tr>
+            <tr>
+              <td>[ \t]+</td> <td>スペースまたはタブ文字が1文字以上(貪欲なマッチ)</td>
+            </tr>
+            <tr>
+              <td>\r</td> <td>復帰文字</td>
+            </tr>
+            <tr>
+              <td>\s</td> <td>[ \t\r\n\f]</td>
+            </tr>
+            <tr>
+              <td>ABC|DEF</td> <td>文字列ABCまたは文字列DEF</td>
+            </tr>
+            <tr>
+              <td>\b</td> <td>単語の境界を表す。</td>
+            </tr>
+            <tr>
+              <td>\B</td> <td>単語の境界以外を表す。</td>
+            </tr>
+            <tr>
+              <td>(?{"<"}=abc)</td> <td>文字列abcの直後を表す(肯定の後読み)</td>
+            </tr>
+            <tr>
+              <td>(?=abc)</td> <td>文字列abcの直前を表す(肯定の先読み)</td>
+            </tr>
+            <tr>
+              <td>(?{"<!"}abc)</td> <td>文字列abc以外の直後を表す(否定の後読み)</td>
+            </tr>
+            <tr>
+              <td>(?!abc)</td> <td>文字列abc以外の直前を表す(否定の先読み)</td>
+            </tr>
+          </table>
         </MetaContentWrapper>
       </MetaMenuBarWrapper>
     </>

--- a/frontend/src/components/Games/MetaMenuBar.jsx
+++ b/frontend/src/components/Games/MetaMenuBar.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { COLORS } from '../../style_constants.js';
 
 const MetaMenuBarWrapper = styled.div`
-  background-color: ${COLORS.SUB};
+  background-color: ${COLORS.MAIN};
   border-radius: 3px;
   height: 490px;
   width: 220px;
@@ -14,19 +14,56 @@ const MetaMenuBarWrapper = styled.div`
 `;
 
 const TitleWrapper = styled.div`
-  height: 60px;
+  height: 50px;
   font-size: 21px;
-  line-height: 60px;
-  color: ${COLORS.BLACK};
+  line-height: 50px;
+  color: ${COLORS.SUB};
   font-family: YuGothic;
-  font-weight: normal;
+  font-weight: bold;
   text-align: center;
 `;
 
+// white-space: nowrapは、カラム内のテキストを折り返さない為に使う
+// overflow-x: autoは横スクロールを可能にする。
+// overflow-y: autoは縦スクロールを可能にする。
 const MetaContentWrapper = styled.div`
-
+  height: 440px;
+  white-space: nowrap;
+  overflow-x: auto; 
+  overflow-y: auto;
 `;
 
+const CustomTable = styled.table`
+  border-collapse: collapse;
+  color: ${COLORS.BLACK};
+  background-color: ${COLORS.SUB};
+  font-family: YuGothic;
+  font-weight: normal;
+`;
+
+const CustomTh = styled.th`
+  padding: 8px 6px; 
+  background-color: ${COLORS.OCHER};
+  position: sticky;
+  top: 0;
+  border-left: solid 1px #c79344;
+  border-right: solid 1px #c79344;
+`;
+
+const MeaningTh = styled(CustomTh)`
+  text-align: left;
+`;
+
+const CustomTd = styled.td`
+  border: solid 1px #c79344;
+  padding: 8px 6px; 
+`;
+
+const MetaTd = styled(CustomTd)`
+  text-align: center;
+`;
+
+// キャプチャ関係は問題で出てこないので、消した
 export const MetaMenuBar = () => {
   return (
     <>
@@ -35,128 +72,122 @@ export const MetaMenuBar = () => {
           メタ文字一覧
         </TitleWrapper>
         <MetaContentWrapper>
-          <table>
+          <CustomTable>
             <tr>
-              <th>メタ文字</th> <th>意味</th>
+              <CustomTh>メタ文字</CustomTh> <MeaningTh>意味</MeaningTh>
             </tr>
             <tr>
-              <td>\d</td> <td>1桁の数字</td>
+              <MetaTd>\d</MetaTd> <CustomTd>1桁の数字</CustomTd>
             </tr>
             <tr>
-              <td>[0-9]</td> <td>1桁の数字</td>
+              <MetaTd>[0-9]</MetaTd> <CustomTd>1桁の数字</CustomTd>
             </tr>
             <tr>
-              <td>\d+</td> <td>1桁以上の数字</td>
+              <MetaTd>\d+</MetaTd> <CustomTd>1桁以上の数字</CustomTd>
             </tr>
             <tr>
-              <td>{'{'}n,m}</td> <td>直前の文字がn個以上、m個以下</td>
+              <MetaTd>{'{'}n,m}</MetaTd> <CustomTd>直前の文字がn個以上、m個以下</CustomTd>
             </tr>
             <tr>
-              <td>{'{'}n}</td> <td>直前の文字がちょうどn個</td>
+              <MetaTd>{'{'}n}</MetaTd> <CustomTd>直前の文字がちょうどn個</CustomTd>
             </tr>
             <tr>
-              <td>{'{'}n,}</td> <td>直前の文字がn個以下</td>
+              <MetaTd>{'{'}n,}</MetaTd> <CustomTd>直前の文字がn個以下</CustomTd>
             </tr>
             <tr>
-              <td>{'{'},n}</td> <td>直前の文字がn個以下</td>
+              <MetaTd>{'{'},n}</MetaTd> <CustomTd>直前の文字がn個以下</CustomTd>
             </tr>
             <tr>
-              <td>[AB]</td> <td>A, Bのいずれか1文字(A, Bは任意の1文字)</td>
+              <MetaTd>[AB]</MetaTd> <CustomTd>A, Bのいずれか1文字(A, Bは任意の1文字)</CustomTd>
             </tr>
             <tr>
-              <td>[ABC]</td> <td>A, B, Cのいずれか1文字(A, B, Cは任意の1文字)</td>
+              <MetaTd>[ABC]</MetaTd> <CustomTd>A, B, Cのいずれか1文字(A, B, Cは任意の1文字)</CustomTd>
             </tr>
             <tr>
-              <td>[a-z]</td> <td>小文字アルファベットのいずれか1文字</td>
+              <MetaTd>[a-z]</MetaTd> <CustomTd>小文字アルファベットのいずれか1文字</CustomTd>
             </tr>
             <tr>
-              <td>?</td> <td>直前の文字が1文字または無し</td>
+              <MetaTd>?</MetaTd> <CustomTd>直前の文字が1文字または無し</CustomTd>
             </tr>
             <tr>
-              <td>(2文字以上の文字列)?</td> <td>直前の文字が2文字以上の文字列または無し</td>
+              <MetaTd>(ABC)?</MetaTd> <CustomTd>文字列ABCまたは無し</CustomTd>
             </tr>
             <tr>
-              <td>.</td> <td>任意の1文字</td>
+              <MetaTd>.</MetaTd> <CustomTd>任意の1文字</CustomTd>
             </tr>
             <tr>
-              <td>\n</td> <td>改行</td>
+              <MetaTd>\n</MetaTd> <CustomTd>改行</CustomTd>
             </tr>
             <tr>
-              <td>+</td> <td>直前の文字が1文字以上</td>
+              <MetaTd>+</MetaTd> <CustomTd>直前の文字が1文字以上</CustomTd>
             </tr>
             <tr>
-              <td>*</td> <td>直前の文字が0文字以上</td>
+              <MetaTd>*</MetaTd> <CustomTd>直前の文字が0文字以上</CustomTd>
             </tr>
             <tr>
-              <td>.+</td> <td>任意の文字が1文字以上(貪欲なマッチ)</td>
+              <MetaTd>.+</MetaTd> <CustomTd>任意の文字が1文字以上(貪欲なマッチ)</CustomTd>
             </tr>
             <tr>
-              <td>.*</td> <td>任意の文字が0文字以上(貪欲なマッチ)</td>
+              <MetaTd>.*</MetaTd> <CustomTd>任意の文字が0文字以上(貪欲なマッチ)</CustomTd>
             </tr>
             <tr>
-              <td>[^A]*</td> <td>A以外の任意の文字が0文字以上</td>
+              <MetaTd>[^A]*</MetaTd> <CustomTd>A以外の任意の文字が0文字以上</CustomTd>
             </tr>
             <tr>
-              <td>.+?</td> <td>任意の文字が1文字以上(控えめなマッチ)</td>
+              <MetaTd>.+?</MetaTd> <CustomTd>任意の文字が1文字以上(控えめなマッチ)</CustomTd>
             </tr>
             <tr>
-              <td>.*?</td> <td>任意の文字が0文字以上(控えめなマッチ)</td>
+              <MetaTd>.*?</MetaTd> <CustomTd>任意の文字が0文字以上(控えめなマッチ)</CustomTd>
             </tr>
             <tr>
-              <td>()</td> <td>()内をキャプチャする。</td>
+              <MetaTd>()</MetaTd> <CustomTd>グループ化。 ()内をキャプチャする機能も併せ持つ。</CustomTd>
             </tr>
             <tr>
-              <td>(?{"<"}name>pattern)</td> <td>名前付きキャプチャ(nameはキャプチャ名)</td>
+              <MetaTd>(?:)</MetaTd> <CustomTd>()と?:を合わせると、キャプチャをしなくなる。</CustomTd>
             </tr>
             <tr>
-              <td>\k{"<"}name></td> <td>名前付きキャプチャで取得した文字列</td>
+              <MetaTd>\w</MetaTd> <CustomTd>[a-zA-Z0-9_]</CustomTd>
             </tr>
             <tr>
-              <td>(?:)</td> <td>()と?:を合わせると、キャプチャをしなくなる。</td>
+              <MetaTd>^</MetaTd> <CustomTd>行頭を表す。</CustomTd>
             </tr>
             <tr>
-              <td>\w</td> <td>[a-zA-Z0-9_]</td>
+              <MetaTd>$</MetaTd> <CustomTd>行末を表す。</CustomTd>
             </tr>
             <tr>
-              <td>^</td> <td>行頭を表す。</td>
+              <MetaTd>\t</MetaTd> <CustomTd>タブ文字</CustomTd>
             </tr>
             <tr>
-              <td>$</td> <td>行末を表す。</td>
+              <MetaTd>[ \t]+</MetaTd> <CustomTd>スペースまたはタブ文字が1文字以上(貪欲なマッチ)</CustomTd>
             </tr>
             <tr>
-              <td>\t</td> <td>タブ文字</td>
+              <MetaTd>\r</MetaTd> <CustomTd>復帰文字</CustomTd>
             </tr>
             <tr>
-              <td>[ \t]+</td> <td>スペースまたはタブ文字が1文字以上(貪欲なマッチ)</td>
+              <MetaTd>\s</MetaTd> <CustomTd>[ \t\r\n\f]</CustomTd>
             </tr>
             <tr>
-              <td>\r</td> <td>復帰文字</td>
+              <MetaTd>ABC|DEF</MetaTd> <CustomTd>文字列ABCまたは文字列DEF</CustomTd>
             </tr>
             <tr>
-              <td>\s</td> <td>[ \t\r\n\f]</td>
+              <MetaTd>\b</MetaTd> <CustomTd>単語の境界を表す。</CustomTd>
             </tr>
             <tr>
-              <td>ABC|DEF</td> <td>文字列ABCまたは文字列DEF</td>
+              <MetaTd>\B</MetaTd> <CustomTd>単語の境界以外を表す。</CustomTd>
             </tr>
             <tr>
-              <td>\b</td> <td>単語の境界を表す。</td>
+              <MetaTd>(?{"<"}=abc)</MetaTd> <CustomTd>文字列abcの直後を表す(肯定の後読み)</CustomTd>
             </tr>
             <tr>
-              <td>\B</td> <td>単語の境界以外を表す。</td>
+              <MetaTd>(?=abc)</MetaTd> <CustomTd>文字列abcの直前を表す(肯定の先読み)</CustomTd>
             </tr>
             <tr>
-              <td>(?{"<"}=abc)</td> <td>文字列abcの直後を表す(肯定の後読み)</td>
+              <MetaTd>(?{"<!"}abc)</MetaTd> <CustomTd>文字列abc以外の直後を表す(否定の後読み)</CustomTd>
             </tr>
             <tr>
-              <td>(?=abc)</td> <td>文字列abcの直前を表す(肯定の先読み)</td>
+              <MetaTd>(?!abc)</MetaTd> <CustomTd>文字列abc以外の直前を表す(否定の先読み)</CustomTd>
             </tr>
-            <tr>
-              <td>(?{"<!"}abc)</td> <td>文字列abc以外の直後を表す(否定の後読み)</td>
-            </tr>
-            <tr>
-              <td>(?!abc)</td> <td>文字列abc以外の直前を表す(否定の先読み)</td>
-            </tr>
-          </table>
+          </CustomTable>
         </MetaContentWrapper>
       </MetaMenuBarWrapper>
     </>

--- a/frontend/src/components/Games/QuestionBlock.jsx
+++ b/frontend/src/components/Games/QuestionBlock.jsx
@@ -55,15 +55,6 @@ const TargetSentenceWrapper = styled.div`
   font-weight: 500;
 `;
 
-/*
-const QuestionSentenceWrapper = styled.div`
-  background-color: ${COLORS.OCHER};
-  border-radius: 3px;
-  width: 795px;
-  height: 54px;
-`;
-*/
-
 export const QuestionBlock = () => {
   return (
     <>

--- a/frontend/src/components/Games/QuestionBlock.jsx
+++ b/frontend/src/components/Games/QuestionBlock.jsx
@@ -63,7 +63,7 @@ export const QuestionBlock = () => {
           <DifficultyWrapper>
             初級
           </DifficultyWrapper>
-          イグアノスの群れが現れた。
+          イグアノスの群れが現れた！
           <TargetSentenceWrapper>
           </TargetSentenceWrapper>
         </QuestionWrapper>

--- a/frontend/src/components/Games/QuestionBlock.jsx
+++ b/frontend/src/components/Games/QuestionBlock.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+const QuestionBlockWrapper = styled.div`
+  background-color: ${COLORS.GRAY};
+  border-radius: 3px;
+  width: 860px;
+  height: 106px;
+`;
+
+const QuestionWrapper = styled.div`
+  background-color: ${COLORS.OCHER};
+  border-radius: 3px;
+  width: 860px;
+  height: 53px;
+  font-size: 23px;
+  line-height: 53px;
+  color: ${COLORS.BLACK};
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+  text-align: center;
+`;
+
+const DifficultyWrapper = styled.div`
+  background-color: ${COLORS.MAIN};
+  border-radius: 3px;
+  width: 75px;
+  height: 53px;
+  font-size: 23px;
+  line-height: 53px;
+  color: ${COLORS.WHITE};
+  text-align: center;
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+  position: absolute;
+  z-index: 1;
+`;
+
+const TargetSentenceWrapper = styled.div`
+  background-color: ${COLORS.SUB};
+  border-radius: 3px;
+  width: 860px;
+  height: 53px;
+  font-size: 23px;
+  line-height: 53px;
+  color: ${COLORS.BLACK};
+  text-align: center;
+  font-family: YuGothic;
+  font-style: normal;
+  font-weight: 500;
+`;
+
+/*
+const QuestionSentenceWrapper = styled.div`
+  background-color: ${COLORS.OCHER};
+  border-radius: 3px;
+  width: 795px;
+  height: 54px;
+`;
+*/
+
+export const QuestionBlock = () => {
+  return (
+    <>
+      <QuestionBlockWrapper>
+        <QuestionWrapper>
+          <DifficultyWrapper>
+            初級
+          </DifficultyWrapper>
+          イグアノスの群れが現れた。
+          <TargetSentenceWrapper>
+          </TargetSentenceWrapper>
+        </QuestionWrapper>
+      </QuestionBlockWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/QuestionBlock.jsx
+++ b/frontend/src/components/Games/QuestionBlock.jsx
@@ -32,7 +32,7 @@ const DifficultyWrapper = styled.div`
   height: 53px;
   font-size: 23px;
   line-height: 53px;
-  color: ${COLORS.WHITE};
+  color: ${COLORS.SUB};
   text-align: center;
   font-family: YuGothic;
   font-style: normal;
@@ -55,7 +55,7 @@ const TargetSentenceWrapper = styled.div`
   font-weight: 500;
 `;
 
-export const QuestionBlock = () => {
+export const QuestionBlock = ({ difficulty }) => {
   return (
     <>
       <QuestionBlockWrapper>
@@ -63,7 +63,24 @@ export const QuestionBlock = () => {
           <DifficultyWrapper>
             初級
           </DifficultyWrapper>
-          イグアノスの群れが現れた！
+          {
+            difficulty === "elementary" &&
+            <>
+              スクータムの群れが現れた！
+            </>
+          }
+          {
+            difficulty === "intermediate" &&
+            <>
+              カスアリウスの群れが現れた！
+            </>
+          }
+          {
+            difficulty === "advanced" &&
+            <>
+              オルファ・ラパクスが現れた！
+            </>
+          }
           <TargetSentenceWrapper>
           </TargetSentenceWrapper>
         </QuestionWrapper>

--- a/frontend/src/components/Games/TimeGage.jsx
+++ b/frontend/src/components/Games/TimeGage.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+const TimeGageWrapper = styled.div`
+  background-color: ${COLORS.LIGHT_BLACK};
+  border-radius: 3px;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  box-sizing: border-box;
+  border: 8px solid;
+  border-color: ${COLORS.GAGE_GRAY};
+`;
+
+const TypeWrapper = styled.div`
+  height: 23px;
+  width: 77px;
+  font-size: 18px;
+  line-height: 23px;
+  background-color: ${COLORS.GAGE_GRAY};
+  color: ${COLORS.BROWN};
+  font-family: YuGothic;
+  font-weight: bold;
+  text-align: center;
+`;
+
+const GageWrapper = styled.div`
+  height: 100%;
+  width: 60%;
+  background-color: ${COLORS.YELLOW};
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+`;
+
+export const TimeGage = () => {
+  return (
+    <>
+      <TimeGageWrapper>
+        <TypeWrapper>
+          TIME
+        </TypeWrapper>
+        <GageWrapper>
+        </GageWrapper>
+      </TimeGageWrapper>
+    </>
+  );
+};

--- a/frontend/src/components/Games/TimeGage.jsx
+++ b/frontend/src/components/Games/TimeGage.jsx
@@ -11,15 +11,15 @@ const TimeGageWrapper = styled.div`
   height: 36px;
   display: flex;
   box-sizing: border-box;
-  border: 8px solid;
+  border: 5px solid;
   border-color: ${COLORS.GAGE_GRAY};
 `;
 
 const TypeWrapper = styled.div`
-  height: 23px;
+  height: 26px;
   width: 77px;
   font-size: 18px;
-  line-height: 23px;
+  line-height: 26px;
   background-color: ${COLORS.GAGE_GRAY};
   color: ${COLORS.BROWN};
   font-family: YuGothic;

--- a/frontend/src/components/Games/TimeGage.jsx
+++ b/frontend/src/components/Games/TimeGage.jsx
@@ -17,7 +17,7 @@ const TimeGageWrapper = styled.div`
 
 const TypeWrapper = styled.div`
   height: 26px;
-  width: 77px;
+  width: 120px;
   font-size: 18px;
   line-height: 26px;
   background-color: ${COLORS.GAGE_GRAY};

--- a/frontend/src/components/Headers/Header.jsx
+++ b/frontend/src/components/Headers/Header.jsx
@@ -122,7 +122,7 @@ export const Header = ({onClickLink}) => {
             ランキング
           </HeaderNavLink>
           {
-            sessionState === false && 
+            sessionState === false && onClickLink && 
               <>
                 <HeaderNavFakeLink onClick={() => onClickLink("login")}>
                   ログイン

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -10,8 +10,9 @@ import { Header } from '../components/Headers/Header.jsx';
 import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
 import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
 import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
-import { Footer } from '../components/Footer.jsx';
 import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
+import { CodeBlock } from '../components/Games/CodeBlock.jsx';
+import { Footer } from '../components/Footer.jsx';
 
 // Contextオブジェクト
 import { UserContext } from "../context/UserProvider.js";
@@ -45,7 +46,7 @@ const MainGameContentWrapper = styled.div`
 const GameBlockWrapper = styled.div`
   display: flex;
   justify-content: start;
-  padding-left: 30px;
+  padding-left: 33px;
 `;
 
 // SlideWrapperコンポーネント
@@ -57,14 +58,14 @@ const SlideWrapper = styled.div`
 const BattleBlockWrapper = styled.div`
   height: 498px;
   width: 920px;
-  margin-left: 5px;
+  margin-left: 7px;
 `;
 
 // MonsterBlockWrapperコンポーネント
 const MonsterBlockWrapper = styled.div`
   height: 370px;
   width: 900px;
-  margin-left: 40px;
+  margin-left: 43px;
   margin-top: 10px;
   display: flex;
   justify-content: space-evenly;
@@ -81,15 +82,13 @@ const QuestionBlockWrapper = styled.div`
 
 // CodeBlockWrapperコンポーネント
 const CodeBlockWrapper = styled.div`
-  height: 70px;
-  width: 100%;
-  background-color: #666666;
+  height: 53px;
   margin-top: 13px;
 `;
 
 // GageBlockWrapperコンポーネント
 const GageBlockWrapper = styled.div`
-  height: 50px;
+  height: 66px;
   width: 100%;
   background-color: #F6F6DC;
   margin-top: 13px;
@@ -174,6 +173,7 @@ export const Games = () => {
             </BattleBlockWrapper>
           </GameBlockWrapper>
           <CodeBlockWrapper>
+            <CodeBlock />
           </CodeBlockWrapper>
           <GageBlockWrapper>
           </GageBlockWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -10,6 +10,8 @@ import { Header } from '../components/Headers/Header.jsx';
 import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
 import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
 import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
+import { IntermediateMonster } from '../components/Games/IntermediateMonster.jsx';
+import { AdvancedMonster } from '../components/Games/AdvancedMonster.jsx';
 import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 import { CodeBlock } from '../components/Games/CodeBlock.jsx';
 import { TimeGage } from '../components/Games/TimeGage.jsx';
@@ -168,9 +170,22 @@ export const Games = () => {
                       <ElementaryMonster />
                     </>
                 }
+                {
+                  difficulty === 'intermediate' &&
+                    <>
+                      <IntermediateMonster />
+                    </>
+                }
+                {
+                  difficulty === 'advanced' &&
+                    <>
+                      <AdvancedMonster />
+                    </>
+      
+                }
               </MonsterBlockWrapper>
               <QuestionBlockWrapper>
-                <QuestionBlock />
+                <QuestionBlock difficulty={difficulty} />
               </QuestionBlockWrapper>
             </BattleBlockWrapper>
           </GameBlockWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useContext } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 // Image
@@ -105,6 +105,8 @@ export const Games = () => {
     requestUserActionTyps
   } = useContext(UserContext);
 
+  const { difficulty } = useParams();
+
   // location
   const location = useLocation();
 
@@ -158,9 +160,14 @@ export const Games = () => {
             </SlideWrapper>
             <BattleBlockWrapper>
               <MonsterBlockWrapper>
-                <ElementaryMonster />
-                <ElementaryMonster />
-                <ElementaryMonster />
+                {
+                  difficulty === 'elementary' && 
+                    <>
+                      <ElementaryMonster />
+                      <ElementaryMonster />
+                      <ElementaryMonster />
+                    </>
+                }
               </MonsterBlockWrapper>
               <QuestionBlockWrapper>
               </QuestionBlockWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -11,6 +11,7 @@ import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
 import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
 import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
 import { Footer } from '../components/Footer.jsx';
+import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 
 // Contextオブジェクト
 import { UserContext } from "../context/UserProvider.js";
@@ -44,7 +45,7 @@ const MainGameContentWrapper = styled.div`
 const GameBlockWrapper = styled.div`
   display: flex;
   justify-content: start;
-  padding-left: 20px;
+  padding-left: 30px;
 `;
 
 // SlideWrapperコンポーネント
@@ -54,17 +55,16 @@ const SlideWrapper = styled.div`
 // BattleBlockWrapperコンポーネント
 // background-color: #F6F6DC;  
 const BattleBlockWrapper = styled.div`
-  margin-left: 25px;
   height: 498px;
   width: 920px;
+  margin-left: 5px;
 `;
 
 // MonsterBlockWrapperコンポーネント
-// background-color: #666666;
 const MonsterBlockWrapper = styled.div`
   height: 370px;
   width: 900px;
-  margin: 0 auto;
+  margin-left: 40px;
   margin-top: 10px;
   display: flex;
   justify-content: space-evenly;
@@ -73,11 +73,10 @@ const MonsterBlockWrapper = styled.div`
 
 // QuestionBlockWrapperコンポーネント
 const QuestionBlockWrapper = styled.div`
-  height: 108px;
-  width: 900px;
-  background-color: #666666;
+  height: 104px;
+  width: 860px;
   margin: 0 auto;
-  margin-top: 10px;
+  margin-top: 13px;
 `;
 
 // CodeBlockWrapperコンポーネント
@@ -170,6 +169,7 @@ export const Games = () => {
                 }
               </MonsterBlockWrapper>
               <QuestionBlockWrapper>
+                <QuestionBlock />
               </QuestionBlockWrapper>
             </BattleBlockWrapper>
           </GameBlockWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -12,7 +12,9 @@ import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
 import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
 import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 import { CodeBlock } from '../components/Games/CodeBlock.jsx';
+import { TimeGage } from '../components/Games/TimeGage.jsx';
 import { Footer } from '../components/Footer.jsx';
+
 
 // Contextオブジェクト
 import { UserContext } from "../context/UserProvider.js";
@@ -176,6 +178,7 @@ export const Games = () => {
             <CodeBlock />
           </CodeBlockWrapper>
           <GageBlockWrapper>
+            <TimeGage />
           </GageBlockWrapper>
         </MainGameContentWrapper>
       </MainContentWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -14,7 +14,7 @@ import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 import { CodeBlock } from '../components/Games/CodeBlock.jsx';
 import { TimeGage } from '../components/Games/TimeGage.jsx';
 import { HpGage } from '../components/Games/HpGage.jsx';
-import { Footer } from '../components/Footer.jsx';
+import { Footer } from '../components/Footers/Footer.jsx';
 
 
 // Contextオブジェクト

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -13,6 +13,7 @@ import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
 import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 import { CodeBlock } from '../components/Games/CodeBlock.jsx';
 import { TimeGage } from '../components/Games/TimeGage.jsx';
+import { HpGage } from '../components/Games/HpGage.jsx';
 import { Footer } from '../components/Footer.jsx';
 
 
@@ -92,7 +93,6 @@ const CodeBlockWrapper = styled.div`
 const GageBlockWrapper = styled.div`
   height: 66px;
   width: 100%;
-  background-color: #F6F6DC;
   margin-top: 13px;
 `;
 
@@ -179,6 +179,7 @@ export const Games = () => {
           </CodeBlockWrapper>
           <GageBlockWrapper>
             <TimeGage />
+            <HpGage />
           </GageBlockWrapper>
         </MainGameContentWrapper>
       </MainContentWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -1,8 +1,72 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useContext } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+// Presentational Components
+import { Header } from '../components/Headers/Header.jsx';
+import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
+
+// Contextオブジェクト
+import { UserContext } from "../context/UserProvider.js";
+
+// ログイン状態を確認するAPIコール関数
+import { checkLoginStatus } from '../apis/checkLoginStatus.js'; 
+
+// HTTP_STATUS_CODE
+import { HTTP_STATUS_CODE } from '../constants';
 
 export const Games = () => {
+
+  // useContext
+  const {
+    requestUserState: { sessionState }, 
+    dispatch, 
+    requestUserActionTyps
+  } = useContext(UserContext);
+
+  // location
+  const location = useLocation();
+
+  // navigation
+  const navigate = useNavigate();
+
+  // React Routerで画面遷移するとユーザーが保持できないので、
+  // useEffectで再度リクエストを出す。
+  useEffect(() => {
+    if(sessionState === false){
+      dispatch({ type: requestUserActionTyps.REQUEST });
+      checkLoginStatus().then((data) => {
+        dispatch({
+          type: requestUserActionTyps.REQUEST_SUCCESS,
+          payload: {
+            session: data.session,
+            user: data.user,
+          }
+        });
+      }).catch((e) => {
+        if(e.response.status === HTTP_STATUS_CODE.NOT_FOUND){
+          dispatch({
+            type: requestUserActionTyps.REQUEST_FAILURE,
+            payload: {
+              errors: e.response.data.errors
+            }
+          });
+        } else {
+          throw e;
+        }
+      })
+    }
+  }, [
+    dispatch, 
+    sessionState,
+    requestUserActionTyps.REQUEST, 
+    requestUserActionTyps.REQUEST_SUCCESS,
+    requestUserActionTyps.REQUEST_FAILURE
+  ]);
+
   return (
     <>
+      <Header />
+      <FakeHeader />
       ゲーム画面
     </>
   );

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -8,6 +8,8 @@ import BackGroundImage from '../images/background.png';
 // Presentational Components
 import { Header } from '../components/Headers/Header.jsx';
 import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
+import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
+import { Footer } from '../components/Footer.jsx';
 
 // Contextオブジェクト
 import { UserContext } from "../context/UserProvider.js";
@@ -20,6 +22,7 @@ import { HTTP_STATUS_CODE } from '../constants';
 
 // MainContentWrapperコンポーネント
 const MainContentWrapper = styled.div`
+  padding-top: 36px;
 `;
 
 // 背景画像
@@ -38,14 +41,9 @@ const MainGameContentWrapper = styled.div`
 
 // GameBlockWrapperコンポーネント
 const GameBlockWrapper = styled.div`
-`;
-
-// CodeBlockWrapperコンポーネント
-const CodeBlockWrapper = styled.div`
-`;
-
-// GageBlockWrapperコンポーネント
-const GageBlockWrapper = styled.div`
+  display: flex;
+  justify-content: start;
+  padding-left: 20px;
 `;
 
 // SlideWrapperコンポーネント
@@ -54,14 +52,44 @@ const SlideWrapper = styled.div`
 
 // BattleBlockWrapperコンポーネント
 const BattleBlockWrapper = styled.div`
+  margin-left: 25px;
+  height: 498px;
+  width: 920px;
+  background-color: #F6F6DC;
 `;
 
 // MonsterBlockWrapperコンポーネント
 const MonsterBlockWrapper = styled.div`
+  height: 370px;
+  width: 900px;
+  background-color: #666666;
+  margin: 0 auto;
+  margin-top: 10px;
 `;
 
 // QuestionBlockWrapperコンポーネント
 const QuestionBlockWrapper = styled.div`
+  height: 108px;
+  width: 900px;
+  background-color: #666666;
+  margin: 0 auto;
+  margin-top: 10px;
+`;
+
+// CodeBlockWrapperコンポーネント
+const CodeBlockWrapper = styled.div`
+  height: 70px;
+  width: 100%;
+  background-color: #666666;
+  margin-top: 13px;
+`;
+
+// GageBlockWrapperコンポーネント
+const GageBlockWrapper = styled.div`
+  height: 50px;
+  width: 100%;
+  background-color: #F6F6DC;
+  margin-top: 13px;
 `;
 
 export const Games = () => {
@@ -122,6 +150,7 @@ export const Games = () => {
         <MainGameContentWrapper>
           <GameBlockWrapper>
             <SlideWrapper>
+              <MetaMenuBar />
             </SlideWrapper>
             <BattleBlockWrapper>
               <MonsterBlockWrapper>
@@ -136,6 +165,7 @@ export const Games = () => {
           </GageBlockWrapper>
         </MainGameContentWrapper>
       </MainContentWrapper>
+      <Footer />
     </>
   );
 };

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -9,6 +9,7 @@ import BackGroundImage from '../images/background.png';
 import { Header } from '../components/Headers/Header.jsx';
 import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
 import { MetaMenuBar } from '../components/Games/MetaMenuBar.jsx';
+import { ElementaryMonster } from '../components/Games/ElementaryMonster.jsx';
 import { Footer } from '../components/Footer.jsx';
 
 // Contextオブジェクト
@@ -51,20 +52,23 @@ const SlideWrapper = styled.div`
 `;
 
 // BattleBlockWrapperコンポーネント
+// background-color: #F6F6DC;  
 const BattleBlockWrapper = styled.div`
   margin-left: 25px;
   height: 498px;
   width: 920px;
-  background-color: #F6F6DC;
 `;
 
 // MonsterBlockWrapperコンポーネント
+// background-color: #666666;
 const MonsterBlockWrapper = styled.div`
   height: 370px;
   width: 900px;
-  background-color: #666666;
   margin: 0 auto;
   margin-top: 10px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: end;
 `;
 
 // QuestionBlockWrapperコンポーネント
@@ -154,6 +158,9 @@ export const Games = () => {
             </SlideWrapper>
             <BattleBlockWrapper>
               <MonsterBlockWrapper>
+                <ElementaryMonster />
+                <ElementaryMonster />
+                <ElementaryMonster />
               </MonsterBlockWrapper>
               <QuestionBlockWrapper>
               </QuestionBlockWrapper>

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -14,7 +14,7 @@ import { QuestionBlock } from '../components/Games/QuestionBlock.jsx';
 import { CodeBlock } from '../components/Games/CodeBlock.jsx';
 import { TimeGage } from '../components/Games/TimeGage.jsx';
 import { HpGage } from '../components/Games/HpGage.jsx';
-import { Footer } from '../components/Footers/Footer.jsx';
+import { GameFooter } from '../components/Footers/GameFooter.jsx';
 
 
 // Contextオブジェクト
@@ -183,7 +183,7 @@ export const Games = () => {
           </GageBlockWrapper>
         </MainGameContentWrapper>
       </MainContentWrapper>
-      <Footer />
+      <GameFooter />
     </>
   );
 };

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -18,7 +18,7 @@ import { checkLoginStatus } from '../apis/checkLoginStatus.js';
 // HTTP_STATUS_CODE
 import { HTTP_STATUS_CODE } from '../constants';
 
-// MainContentのラッパー
+// MainContentWrapperコンポーネント
 const MainContentWrapper = styled.div`
 `;
 
@@ -30,6 +30,38 @@ const BackGroundImageCover = styled.img`
   top: 55px;
   left: -350px;
   z-index: -4;
+`;
+
+// MainGameContentWrapperコンポーネント
+const MainGameContentWrapper = styled.div`
+`;
+
+// GameBlockWrapperコンポーネント
+const GameBlockWrapper = styled.div`
+`;
+
+// CodeBlockWrapperコンポーネント
+const CodeBlockWrapper = styled.div`
+`;
+
+// GageBlockWrapperコンポーネント
+const GageBlockWrapper = styled.div`
+`;
+
+// SlideWrapperコンポーネント
+const SlideWrapper = styled.div`
+`;
+
+// BattleBlockWrapperコンポーネント
+const BattleBlockWrapper = styled.div`
+`;
+
+// MonsterBlockWrapperコンポーネント
+const MonsterBlockWrapper = styled.div`
+`;
+
+// QuestionBlockWrapperコンポーネント
+const QuestionBlockWrapper = styled.div`
 `;
 
 export const Games = () => {
@@ -87,6 +119,22 @@ export const Games = () => {
       <FakeHeader />
       <MainContentWrapper>
         <BackGroundImageCover src={BackGroundImage} />
+        <MainGameContentWrapper>
+          <GameBlockWrapper>
+            <SlideWrapper>
+            </SlideWrapper>
+            <BattleBlockWrapper>
+              <MonsterBlockWrapper>
+              </MonsterBlockWrapper>
+              <QuestionBlockWrapper>
+              </QuestionBlockWrapper>
+            </BattleBlockWrapper>
+          </GameBlockWrapper>
+          <CodeBlockWrapper>
+          </CodeBlockWrapper>
+          <GageBlockWrapper>
+          </GageBlockWrapper>
+        </MainGameContentWrapper>
       </MainContentWrapper>
     </>
   );

--- a/frontend/src/containers/Games.jsx
+++ b/frontend/src/containers/Games.jsx
@@ -1,5 +1,9 @@
 import React, { Fragment, useEffect, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+// Image
+import BackGroundImage from '../images/background.png';
 
 // Presentational Components
 import { Header } from '../components/Headers/Header.jsx';
@@ -13,6 +17,20 @@ import { checkLoginStatus } from '../apis/checkLoginStatus.js';
 
 // HTTP_STATUS_CODE
 import { HTTP_STATUS_CODE } from '../constants';
+
+// MainContentのラッパー
+const MainContentWrapper = styled.div`
+`;
+
+// 背景画像
+const BackGroundImageCover = styled.img`
+  width: 1790px;
+  height: 734px;
+  position: absolute;
+  top: 55px;
+  left: -350px;
+  z-index: -4;
+`;
 
 export const Games = () => {
 
@@ -67,7 +85,9 @@ export const Games = () => {
     <>
       <Header />
       <FakeHeader />
-      ゲーム画面
+      <MainContentWrapper>
+        <BackGroundImageCover src={BackGroundImage} />
+      </MainContentWrapper>
     </>
   );
 };

--- a/frontend/src/containers/LandingPages.jsx
+++ b/frontend/src/containers/LandingPages.jsx
@@ -17,7 +17,7 @@ import { Header } from '../components/Headers/Header.jsx';
 import { FakeHeader } from '../components/Headers/FakeHeader.jsx';
 import { SubText } from '../components/SubText.jsx';
 import { StartButton } from '../components/Buttons/StartButton.jsx'
-import { Footer } from '../components/Footer.jsx';
+import { Footer } from '../components/Footers/Footer.jsx';
 import { LoginDialog } from '../components/Dialogs/LoginDialog.jsx';
 import { SignUpDialog } from '../components/Dialogs/SignUpDialog.jsx';
 import { SessionFlashMessage } from '../components/FlashMessages/SessionFlashMessage.jsx';

--- a/frontend/src/style_constants.js
+++ b/frontend/src/style_constants.js
@@ -13,6 +13,7 @@ export const COLORS = {
   PINK: '#F7ADC3',
   LIGHT_BLUE: '#66BBFF',
   GRAY: '#C4C4C4',
+  LIGHT_BLACK: '#666666',
   OCHER: '#D3AA6B'
 }
 

--- a/frontend/src/style_constants.js
+++ b/frontend/src/style_constants.js
@@ -12,7 +12,8 @@ export const COLORS = {
   BLACK: '#333333',
   PINK: '#F7ADC3',
   LIGHT_BLUE: '#66BBFF',
-  GRAY: '#C4C4C4'
+  GRAY: '#C4C4C4',
+  OCHER: '#D3AA6B'
 }
 
 // フォントサイズを決める際に、適宜定義する。

--- a/frontend/src/style_constants.js
+++ b/frontend/src/style_constants.js
@@ -14,7 +14,9 @@ export const COLORS = {
   LIGHT_BLUE: '#66BBFF',
   GRAY: '#C4C4C4',
   LIGHT_BLACK: '#666666',
-  OCHER: '#D3AA6B'
+  OCHER: '#D3AA6B',
+  YELLOW: '#EBA12F',
+  GAGE_GRAY: '#BBB8AA'
 }
 
 // フォントサイズを決める際に、適宜定義する。

--- a/frontend/src/style_constants.js
+++ b/frontend/src/style_constants.js
@@ -12,6 +12,7 @@ export const COLORS = {
   BLACK: '#333333',
   PINK: '#F7ADC3',
   LIGHT_BLUE: '#66BBFF',
+  GRAY: '#C4C4C4'
 }
 
 // フォントサイズを決める際に、適宜定義する。


### PR DESCRIPTION
## 関連するissue
- ref  #97 
- resolved #97 

## 概要
以下を実行しました。
 - ゲーム画面の作成
 
## 確認事項
-  ゲーム画面が以下のように表示されている。

[![Image from Gyazo](https://i.gyazo.com/49e461c6cb272b22667bf17354843116.jpg)](https://gyazo.com/49e461c6cb272b22667bf17354843116)
## 確認方法
ゲーム画面で確認できます。

## 懸念点
実際にこの画面をどうやって変化させるのかは不透明です。Game.jsxに一通りのstateを持たせようと思います。

## 参考記事
 - [JavaScript の正規表現では \A や \z が使えない。](https://monry.hatenablog.com/entry/2011/12/02/165623)
 - [React(JSX)で波括弧をエスケープしたい](https://yucatio.hatenablog.com/entry/2019/12/08/215543)
 - [HTMLのtable（テーブル）コンプリートガイド](https://code-kitchen.dev/html/table/)
 - [herokuで常時SSL化（rails)](https://qiita.com/akkyta/items/9723398de51febfed65a)
 - [border](https://developer.mozilla.org/ja/docs/Web/CSS/border)
 - [border-radius](https://developer.mozilla.org/ja/docs/Web/CSS/border-radius)
 - [【CSS】box-sizing:border-boxの使い方｜効かない時は？](https://saruwakakun.com/html-css/reference/box-sizing)
 - [CSSのグラデーション（linear-gradient）の使い方を総まとめ！](https://saruwakakun.com/html-css/basic/linear-radial-gradient#section12)
 - [border-color](https://developer.mozilla.org/ja/docs/Web/CSS/border-color)
 - [font-weight](https://developer.mozilla.org/ja/docs/Web/CSS/font-weight)
 - [【React】onChangeで値を取得する方法](https://qiita.com/shungo_m/items/b655258d9ba76879202c)
 - [Reactでinputを扱う(TypeScript版)](https://zenn.dev/takaki/articles/react-input-typescript)
 - [入力欄にフォーカスをあてる](https://code-kitchen.dev/html/input/)
 - [Facing issue while adding radio button in react - input is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`](https://stackoverflow.com/questions/51915053/facing-issue-while-adding-radio-button-in-react-input-is-a-void-element-tag-an)
 - [テキスト入力欄のフォーカス時にChromeなどが自動付加する枠線を消す方法](https://www.nishishi.com/css/chrome-textform-clear-border.html)
 - [Reactで画面遷移先に値を送る](https://qiita.com/oda3104/items/de5489cd97ba674cbee5)
 - [React Hooks useState state の更新にハマる](https://chaika.hatenablog.com/entry/2020/01/03/090000)
 - [【React】「useStateの値を更新しても反映されない！」の解決方法](https://zenn.dev/syu/articles/3c4aa813b57b8c)
 - [Reactでkeydownイベントを取得する方法](https://zenn.dev/naoki/articles/b45f0d1b79808b2d307e)
 - [【HTML / CSS】Position と z-index についてのメモ](https://hidekazu-blog.com/html-css-position-zindex/)
 - [useParams](https://ajike.github.io/react-router-dom_hooks/#useparams)
 - [align-items](https://developer.mozilla.org/ja/docs/Web/CSS/align-items)
 - [【CSS】box-sizing:border-boxの使い方｜効かない時は？](https://saruwakakun.com/html-css/reference/box-sizing)
 - [object-fit](https://developer.mozilla.org/ja/docs/Web/CSS/object-fit)
 - [【css】display: flex; が効かないときの原因の一例](https://work-note32.com/css-display-flex-error)
 - [【display】インラインブロック要素の性質と使い方](https://www.itra.co.jp/webmedia/what-is-inline-block.html)
 - [justify-content](https://developer.mozilla.org/ja/docs/Web/CSS/justify-content)
 - [【CSS】outlineの特徴まとめ 〜borderとの違いまで〜](https://takayamato.com/code/outline-border/)
 - [overflow-x](https://kouhekikyozou.com/css_horizontal_scroll)
 - [HTMLのtable（テーブル）コンプリートガイド](https://code-kitchen.dev/html/table/#%E5%89%8D%E6%8F%90%EF%BC%9A%E8%A6%8B%E3%81%9F%E7%9B%AE%E3%81%AFcss%E3%81%A7%E5%A4%89%E6%9B%B4%E3%81%97%E3%82%88%E3%81%86)
 - [Information of Color #d3aa6b](https://allconverters.org/color/d3aa6b)
 - [#ececb3 Color Hex](https://www.color-hex.com/color/ececb3)
 - [[CSS] table の列固定に position: sticky を使用して背景色を指定すると、枠線が消えてしまう](https://curecode.jp/tech/css-table-position-sticky-with-background-border-vanished/)
 - [background-clipとは？基本的な使い方から値を指定する方法まで解説](background-clipとは？基本的な使い方から値を指定する方法まで解説)
 - [#71a115 Color Hex](https://www.color-hex.com/color/71a115)