### PR TITLE
Add: プレースホルダーを追加した

### DIFF
--- a/frontend/src/components/Games/CodeBlock.jsx
+++ b/frontend/src/components/Games/CodeBlock.jsx
@@ -39,6 +39,18 @@ const CodeBlockInput = styled.input`
   outline: none;
   border: none;
   text-align: center;
+  ::placeholder {
+    color: #eeeeee;
+    opacity: 0.5;
+  };
+  ::-webkit-input-placeholder {
+    color: #eeeeee;
+    opacity: 0.5;
+  };
+  :-ms-input-placeholder {
+    color: #eeeeee;
+    opacity: 0.5;
+  }
 `;
 
 export const CodeBlock = () => {
@@ -64,6 +76,7 @@ export const CodeBlock = () => {
           id='code-block' 
           value={state} 
           onChange={(e) => handleInput(e)} 
+          placeholder="Input Your Regex"
         />
         <AnchorWrapper>
           /g


### PR DESCRIPTION
## 関連するissue
- ref  #102 
- resolved #102 

## 概要
以下を実行しました。
- プレースホルダーを追加した。
 
## 確認事項
-  プレースホルダーが存在する。

## 確認方法
- ゲームスタートの画面から確認できます。

## 懸念点
特に無し。

## 参考記事
 - [「入力する」を意味する英語表現【enter, input, type in】](https://hoz-web.com/entry-input-type-in/)
 - [<input placeholder> …… 入力欄に初期表示する内容を指定する](http://www.htmq.com/html5/input_placeholder.shtml)
 - [モノトーンのカラーコードが一目でわかるWEB色見本](https://www.colordic.org/monotone)
 - [Change the color of a TextInput placeholder with Styled Components in React Native](https://stackoverflow.com/questions/56330061/change-the-color-of-a-textinput-placeholder-with-styled-components-in-react-nati)
 - [【CSS】opacityで画像や文字などを透過させる方法](https://saruwakakun.com/html-css/basic/opacity)