### PR TITLE
Add: 画像アイコン付きメニューを作成する。

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ function App() {
 
             {/* アカウント設定ページ */}
             <Route 
-              exact path="/users/:user_id/account-settings" 
+              exact path="/account-settings" 
               element={<AccountSettings />} 
             />
 

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -1,46 +1,57 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
+// MUI
+import IconButton from '@mui/material/IconButton';
 import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 
 // Colors
 import { COLORS } from '../../style_constants.js';
 
-const CustomDiv = styled.div`
-  position: relative;
-`
-const CustomUl = styled.ul`
-  position: absolute;
-  background-color: ${COLORS.WHITE};
-`;
-
 export const IconMenu = () => {
 
-  const [isOpen, setIsOpen] = useState(false)
-  const menuRef = useRef()
+  const [anchorEl, setAnchorEl] = useState(null);
 
-  useEffect(() => {
-    isOpen && menuRef.current.focus()
-  }, [isOpen])
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   return (
-    <>
-      <CustomDiv>
-        <div onClick={ () => setIsOpen(isOpen ? false : true) }>
-          <MenuOutlinedIcon />
-        </div>
-        {
-          isOpen &&
-          <CustomUl  
-            onBlur={() => setTimeout(() => setIsOpen(false), 100)} 
-            ref={menuRef}
-            tabIndex={1}
-          >
-            <li>menu1</li>
-            <li>menu2</li>
-          </CustomUl>
-        }
-      </CustomDiv>
-    </>
+    <div>
+      <IconButton
+        size="large"
+        aria-label="account of current user"
+        aria-controls="menu-appbar"
+        aria-haspopup="true"
+        onClick={handleMenu}
+        color="inherit"
+      >
+        <MenuOutlinedIcon />
+      </IconButton>
+      <Menu
+        id="menu-appbar"
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        keepMounted
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleClose}>Profile</MenuItem>
+        <MenuItem onClick={handleClose}>My account</MenuItem>
+      </Menu>
+    </div>
   );
 };

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -7,6 +7,8 @@ import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 
+import { BaseLink } from '../shared_style.js';
+
 // Colors
 import { COLORS } from '../../style_constants.js';
 
@@ -49,8 +51,21 @@ export const IconMenu = () => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        <MenuItem onClick={handleClose}>Profile</MenuItem>
-        <MenuItem onClick={handleClose}>My account</MenuItem>
+        <MenuItem 
+          component={BaseLink}
+          to="/my-page"
+          onClick={handleClose}
+        >
+          マイページ
+        </MenuItem>
+        <MenuItem 
+          component={BaseLink}
+          to="/account-settings"
+          onClick={handleClose}
+        >
+          アカウント設定
+        </MenuItem>
+        <MenuItem onClick={handleClose}>ログアウト</MenuItem>
       </Menu>
     </>
   );

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -6,6 +6,14 @@ import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
 // Colors
 import { COLORS } from '../../style_constants.js';
 
+const CustomDiv = styled.div`
+  position: relative;
+`
+const CustomUl = styled.ul`
+  position: absolute;
+  background-color: ${COLORS.WHITE};
+`;
+
 export const IconMenu = () => {
 
   const [isOpen, setIsOpen] = useState(false)
@@ -17,22 +25,22 @@ export const IconMenu = () => {
 
   return (
     <>
-      <div>
-        <div onClick={ () => setIsOpen(isOpen ? false : true)} }>
+      <CustomDiv>
+        <div onClick={ () => setIsOpen(isOpen ? false : true) }>
           <MenuOutlinedIcon />
         </div>
         {
           isOpen &&
-          <ul  
+          <CustomUl  
             onBlur={() => setTimeout(() => setIsOpen(false), 100)} 
             ref={menuRef}
             tabIndex={1}
           >
-            <li><a href="/somewhere">menu1</a></li>
+            <li>menu1</li>
             <li>menu2</li>
-          </ul>
+          </CustomUl>
         }
-      </div>
+      </CustomDiv>
     </>
   );
 };

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -23,7 +23,7 @@ export const IconMenu = () => {
   };
 
   return (
-    <div>
+    <>
       <IconButton
         size="large"
         aria-label="account of current user"
@@ -52,6 +52,6 @@ export const IconMenu = () => {
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
       </Menu>
-    </div>
+    </>
   );
 };

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -12,7 +12,9 @@ import { BaseLink } from '../shared_style.js';
 // Colors
 import { COLORS } from '../../style_constants.js';
 
-export const IconMenu = () => {
+export const IconMenu = ({
+  handleLogout
+}) => {
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -65,7 +67,7 @@ export const IconMenu = () => {
         >
           アカウント設定
         </MenuItem>
-        <MenuItem onClick={handleClose}>ログアウト</MenuItem>
+        <MenuItem onClick={handleLogout}>ログアウト</MenuItem>
       </Menu>
     </>
   );

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -3,11 +3,14 @@ import styled from 'styled-components';
 
 // MUI
 import IconButton from '@mui/material/IconButton';
-import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Avatar from '@mui/material/Avatar';
 
 import { BaseLink } from '../shared_style.js';
+
+// Images
+import TemporaryUserImage from '../../images/temporary_user_image.png';
 
 // Colors
 import { COLORS } from '../../style_constants.js';
@@ -36,7 +39,11 @@ export const IconMenu = ({
         onClick={handleMenu}
         color="inherit"
       >
-        <MenuOutlinedIcon />
+        <Avatar 
+          alt="user-icon" 
+          src={TemporaryUserImage} 
+          sx={{ width: 32, height: 32 }}
+        />
       </IconButton>
       <Menu
         id="menu-appbar"

--- a/frontend/src/components/Games/IconMenu.jsx
+++ b/frontend/src/components/Games/IconMenu.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+
+import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
+
+// Colors
+import { COLORS } from '../../style_constants.js';
+
+export const IconMenu = () => {
+
+  const [isOpen, setIsOpen] = useState(false)
+  const menuRef = useRef()
+
+  useEffect(() => {
+    isOpen && menuRef.current.focus()
+  }, [isOpen])
+
+  return (
+    <>
+      <div>
+        <div onClick={ () => setIsOpen(isOpen ? false : true)} }>
+          <MenuOutlinedIcon />
+        </div>
+        {
+          isOpen &&
+          <ul  
+            onBlur={() => setTimeout(() => setIsOpen(false), 100)} 
+            ref={menuRef}
+            tabIndex={1}
+          >
+            <li><a href="/somewhere">menu1</a></li>
+            <li>menu2</li>
+          </ul>
+        }
+      </div>
+    </>
+  );
+};

--- a/frontend/src/components/Headers/Header.jsx
+++ b/frontend/src/components/Headers/Header.jsx
@@ -1,6 +1,9 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 
+// アイコン付きメニュー
+import { IconMenu } from '../Games/IconMenu.jsx' 
+
 // Images
 import TitleImage from '../../images/title.png';
 
@@ -136,6 +139,9 @@ export const Header = ({onClickLink}) => {
               <>
                 <HeaderNavFakeLink onClick={handleLogout}>
                   ログアウト
+                </HeaderNavFakeLink>
+                <HeaderNavFakeLink>
+                  <IconMenu />
                 </HeaderNavFakeLink>
               </>
           }

--- a/frontend/src/components/Headers/Header.jsx
+++ b/frontend/src/components/Headers/Header.jsx
@@ -137,11 +137,10 @@ export const Header = ({onClickLink}) => {
           { 
             sessionState && userState && 
               <>
-                <HeaderNavFakeLink onClick={handleLogout}>
-                  ログアウト
-                </HeaderNavFakeLink>
                 <HeaderNavFakeLink>
-                  <IconMenu />
+                  <IconMenu 
+                    handleLogout={handleLogout}
+                  />
                 </HeaderNavFakeLink>
               </>
           }

--- a/frontend/src/containers/AccountSettings.jsx
+++ b/frontend/src/containers/AccountSettings.jsx
@@ -1,6 +1,34 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useContext } from 'react';
+
+// Contextオブジェクト
+import { UserContext } from "../context/UserProvider.js";
 
 export const AccountSettings = () => {
+
+  // useContext
+  // requestUserStateには、requestState, userState, errorsが格納されている
+  // userStateにはsessionとuserが格納されている
+  const { 
+    requestUserState: { 
+      sessionState,
+      battleAudioState
+    },
+    dispatch, 
+    requestUserActionTyps
+  } = useContext(UserContext);
+
+  // ゲーム中のユーザーがトップページに戻ったときに
+  // 音を消すuseEffect
+  useEffect(() => {
+    if(battleAudioState.play) {
+      battleAudioState.audio.pause();
+      battleAudioState.audio.currentTime = 0;
+    }
+  },[
+    battleAudioState.play,
+    battleAudioState.audio
+  ])
+
   return (
     <>
       アカウント設定画面

--- a/frontend/src/containers/MyPages.jsx
+++ b/frontend/src/containers/MyPages.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useContext, useLayoutEffect, useState } from 'react';
+import React, { Fragment, useContext, useEffect, useLayoutEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -138,7 +138,8 @@ export const MyPages = () => {
   const { 
     requestUserState: { 
       sessionState,
-      userState: { user }
+      userState: { user },
+      battleAudioState
     },
     dispatch, 
     requestUserActionTyps
@@ -247,6 +248,18 @@ export const MyPages = () => {
   }, [
     user,
   ]);
+
+  // ゲーム中のユーザーがトップページに戻ったときに
+  // 音を消すuseEffect
+  useEffect(() => {
+    if(battleAudioState.play) {
+      battleAudioState.audio.pause();
+      battleAudioState.audio.currentTime = 0;
+    }
+  },[
+    battleAudioState.play,
+    battleAudioState.audio
+  ])
 
   // location
   const location = useLocation();

--- a/frontend/src/containers/Rankings.jsx
+++ b/frontend/src/containers/Rankings.jsx
@@ -1,6 +1,34 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useContext } from 'react';
+
+// Contextオブジェクト
+import { UserContext } from "../context/UserProvider.js";
 
 export const Rankings = () => {
+
+  // useContext
+  // requestUserStateには、requestState, userState, errorsが格納されている
+  // userStateにはsessionとuserが格納されている
+  const { 
+    requestUserState: { 
+      sessionState,
+      battleAudioState
+    },
+    dispatch, 
+    requestUserActionTyps
+  } = useContext(UserContext);
+
+  // ゲーム中のユーザーがトップページに戻ったときに
+  // 音を消すuseEffect
+  useEffect(() => {
+    if(battleAudioState.play) {
+      battleAudioState.audio.pause();
+      battleAudioState.audio.currentTime = 0;
+    }
+  },[
+    battleAudioState.play,
+    battleAudioState.audio
+  ])
+
   return (
     <>
       ランキング一覧画面


### PR DESCRIPTION
## 関連するissue
- ref  #85 
- resolved #85 

## 概要
以下を実行しました。
 - 画像アイコン付きメニューを作成する。
 
## 確認事項
-  画像アイコン付きメニューが以下の動画のように表示されている。

https://user-images.githubusercontent.com/82201718/150300159-aa9c2006-c457-4d39-af2e-28ed512beb8c.mp4


## 確認方法
マイページへアクセスしていただけると確認できます。

## 懸念点
アイコンの画像をユーザーに応じて動的に変換する処理はまだやっていません。
アカウント設定機能を作成したら、取り組む予定です。

## 参考記事
 - [Reactでドロップダウン(dropdown)メニューを実装する](https://qiita.com/satokiyoshino/items/ab4c9671b620c951f690)
 - [Icon API](https://mui.com/api/icon/)
 - [Material-UI + React Router - #7 Navigation Menu](https://www.youtube.com/watch?v=Jkj_XP80h1k)
 - [App Bar](https://mui.com/components/app-bar/)
 - [MenuItem API](https://mui.com/api/menu-item/)
 - [Material UI Menu using routes](https://stackoverflow.com/questions/32106513/material-ui-menu-using-routes)
 - [Avatar](https://mui.com/components/avatars/)