### PR TITLE
Add: Faker gemを本番環境でもインストールできるように設定した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,6 @@ group :development, :test do
   gem 'sqlite3', '~> 1.4'
   # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
-
-  # Use it to create data
-  gem 'faker'
 end
 
 group :development do
@@ -72,3 +69,6 @@ gem 'sorcery'
 
 # APIとクライアント側を一つのコマンドで動かす為に導入する。
 gem 'foreman'
+
+# Use it to create data
+gem 'faker'


### PR DESCRIPTION
## 関連するissue
- ref  #127 
- resolved #127 
## 概要
以下を実行しました。
- Faker gemを全環境でインストールできるように設定
## 確認事項
-  Faker gemが全環境でインストールできるように指定されている。

## 確認方法
Gemfileから確認できます。

## 懸念点
特になし。

## 参考記事
 - [rails gemインストールの環境指定](https://qiita.com/savaniased/items/e9eba5620b92bded77d0)