### PR TITLE
Improve: ランキングページをレスポンシブ対応させた

### DIFF
--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -4,13 +4,13 @@ class Api::V1::RankingsController < ApplicationController
 
   # 自分のランクを表示する部分は一旦保留。かなりムズイ
   def index
-    top_three_elementary = get_top_three("elementary")
-    top_three_intermediate = get_top_three("intermediate")
-    top_three_advanced = get_top_three("advanced")
+    top_ten_elementary = get_top_ten("elementary")
+    top_ten_intermediate = get_top_ten("intermediate")
+    top_ten_advanced = get_top_ten("advanced")
     render json: {
-      top_three_elementary: top_three_elementary,
-      top_three_intermediate: top_three_intermediate,
-      top_three_advanced: top_three_advanced
+      top_ten_elementary: top_ten_elementary,
+      top_ten_intermediate: top_ten_intermediate,
+      top_ten_advanced: top_ten_advanced
     }, status: :ok
   end
 
@@ -25,25 +25,27 @@ class Api::V1::RankingsController < ApplicationController
   # Arrayクラスのオブジェクトに変換する
   # 複数のゲームマネジメントに対して1人のユーザーが存在するので(N対1)
   # eager_loadで左外部結合をした。
-  # おかげで、1回のクエリで上位3つの速さのゲームデータとユーザーを取得できた
-  def get_top_three(difficulty)
+  # ユーザー1人に対して、プロフィール画像が1つ存在しているので、
+  # そのプロフィール画像もeager_loadで取得する
+  # おかげで、1回のクエリで上位3つの速さのゲームデータ, ユーザー, 画像を取得できる
+  def get_top_ten(difficulty)
     user_id = User.where(open_rank: true).pluck(:id)
-    three_game_managements = GameManagement.where(
-                                              difficulty: difficulty,
-                                              game_result: :win,
-                                              user_id: user_id
-                                            ).order(:result_time).limit(10).
-                                            eager_load(:user)
-    top_three_array = three_game_managements.to_a.map do |game_management|
-                        {
-                          game_management: game_management,
-                          user: {
-                            name: game_management.user[:name],
-                            rank: game_management.user[:rank],
-                            active_title: game_management.user[:active_title],
-                            image: game_management.user.avatar.attached? ? url_for(game_management.user.avatar) : nil
-                          }
-                        }
-                      end
+    top_ten_array = GameManagement.where(
+                                     difficulty: difficulty,
+                                     game_result: :win,
+                                     user_id: user_id
+                                   ).order(:result_time).limit(10).
+                                   eager_load(user: { avatar_attachment: :blob }).to_a.
+                                   map do |game_management|
+                                     {
+                                       game_management: game_management,
+                                       user: {
+                                         name: game_management.user[:name],
+                                         rank: game_management.user[:rank],
+                                         active_title: game_management.user[:active_title],
+                                         image: game_management.user.avatar.attached? ? url_for(game_management.user.avatar) : nil
+                                       }
+                                     }
+                                   end
   end
 end

--- a/frontend/src/components/Games/RankingBox.jsx
+++ b/frontend/src/components/Games/RankingBox.jsx
@@ -31,8 +31,7 @@ const TitleLineWrapper = styled.div`
 
 const ChangeGraphBoxSentenceWrapper = styled(DescriptionWrapper)`
   font-weight: bold;
-  font-size: 36px;
-  line-height: 54px;
+  font-size: 2.3em;
   text-align: center;
   padding-top: 1.1%;
 `;
@@ -40,7 +39,7 @@ const ChangeGraphBoxSentenceWrapper = styled(DescriptionWrapper)`
 const RankingWrapper = styled.div`
  width: 80%;
  margin: 0 auto;
- margin-top: 20px;
+ margin-top: 2%;
 `;
 
 const CustomThead = styled.thead`
@@ -51,18 +50,17 @@ const CustomTable = styled.table`
   border-collapse: collapse;
   color: ${COLORS.BLACK};
   background-color: ${COLORS.WHITE};
-  font-family: YuGothic;
   font-weight: normal;
-  font-size: 18px;
+  font-size: 1.1em;
   margin: 0 auto;
-  margin-top: 8px;
   box-shadow: 0 0px 20px rgba(0,0,0,0.2);
   width: 80%;
   border: 1px solid rgba(0,0,0,.2);
+  margin-bottom: 2%;
 `;
 
 const RankingTd = styled.td`
-  padding 10px 0;
+  padding: 1.3% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
@@ -71,7 +69,7 @@ const RankingTd = styled.td`
 `;
 
 const TimeTd = styled.td`
-  padding: 10px 0; 
+  padding: 1.3% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
@@ -80,7 +78,7 @@ const TimeTd = styled.td`
 `;
 
 const HunterTd = styled.td`
-  padding: 10px 0; 
+  padding: 1.3% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
@@ -89,25 +87,25 @@ const HunterTd = styled.td`
 `;
 
 const RankingDataTd = styled.td`
-  padding: 10px 0; 
+  padding: 1.5% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
   width: 10%;
-  font-size: 20px;
+  font-size: 1.5em;
 `;
 
 const TimeDataTd = styled.td`
-  padding: 10px 0; 
+  padding: 1.5% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
   width: 30%;
-  font-size: 20px;
+  font-size: 1.4em;
 `;
 
 const HunterDataTd = styled.td`
-  padding: 10px 0; 
+  padding: 1.5% 0; 
   border: none;
   text-align: center;
   border-bottom:solid 1px silver;
@@ -130,48 +128,47 @@ const HunterTableWrapper = styled.div`
 `;
 
 const HunterTable = styled.table`
-  width: 400px;
+  width: 22vw;
   border-collapse: collapse;
   color: ${COLORS.BLACK};
-  font-family: YuGothic;
   font-weight: normal;
-  font-size: 18px;
+  font-size: 1.1em;
   margin: 0 auto;
   border: none;
 `;
 
 const HunterTableTd = styled.td`
-  padding: 5px 30px; 
+  padding: 2% 4%; 
   border: none;
   text-align: right;
   border-bottom:solid 1px silver;
 `;
 
 const HunterTableNameTd = styled(HunterTableTd)`
-  font-family: YuGothic;
   font-style: normal;
   font-weight: bold;
-  font-size: 24px;
+  font-size: 1.3em;
   text-align: left;
   color: ${COLORS.BLACK};
 `;
 
-const HunterTableMetaTd = styled(HunterTableTd)`
+const HunterTableRankMetaTd = styled(HunterTableTd)`
   border: none;
   text-align: left;
   border-bottom:solid 1px silver;
   font-weight: bold;
+  width: 35%;
 `;
 
-const HunterTableRankMetaTd = styled.td`
-  padding: 5px 30px; 
+const HunterTableTitleMetaTd = styled.td`
+  padding: 2% 4%; 
   border: none;
   text-align: left;
   font-weight: bold;
 `;
 
-const HunterTableRankDataTd = styled.td`
-  padding: 5px 30px; 
+const HunterTableTitleDataTd = styled.td`
+  padding: 2% 4%; 
   border: none;
   text-align: right;
 `;
@@ -181,7 +178,7 @@ const NotDescriptionWrapper = styled(DescriptionWrapper)`
 
 const NotRankingWrapper = styled(RankingWrapper)`
  width: 100%;
- height: 475px;
+ height: 59.1vh;
  text-align: center;
 `;
 
@@ -328,20 +325,20 @@ export const RankingBox = memo(({
                                   </HunterTableNameTd>
                                 </tr>
                                 <tr>
-                                  <HunterTableMetaTd>
+                                  <HunterTableRankMetaTd>
                                     ランク
-                                  </HunterTableMetaTd>
+                                  </HunterTableRankMetaTd>
                                   <HunterTableTd>
                                     {rank}
                                   </HunterTableTd>
                                 </tr>
                                 <tr>
-                                  <HunterTableRankMetaTd>
+                                  <HunterTableTitleMetaTd>
                                     称号
-                                  </HunterTableRankMetaTd>
-                                  <HunterTableRankDataTd>
+                                  </HunterTableTitleMetaTd>
+                                  <HunterTableTitleDataTd>
                                     {active_title}
-                                  </HunterTableRankDataTd>
+                                  </HunterTableTitleDataTd>
                                 </tr>
                               </tbody>
                             </HunterTable>

--- a/frontend/src/components/Games/RankingBox.jsx
+++ b/frontend/src/components/Games/RankingBox.jsx
@@ -183,7 +183,7 @@ const NotRankingWrapper = styled(RankingWrapper)`
 `;
 
 export const RankingBox = memo(({
-  current_top_three_array,
+  current_top_ten_array,
   difficulty_title,
   setRankingState
 }) => {
@@ -192,7 +192,7 @@ export const RankingBox = memo(({
   const handleElementary = () => {
     setRankingState((prev) => ({
       ...prev,
-      current_top_three_array: prev.top_three_elementary,
+      current_top_ten_array: prev.top_ten_elementary,
       difficulty_title: "初級編"
     }));
   };
@@ -201,7 +201,7 @@ export const RankingBox = memo(({
   const handleIntermediate = () => {
     setRankingState((prev) => ({
       ...prev,
-      current_top_three_array: prev.top_three_intermediate,
+      current_top_ten_array: prev.top_ten_intermediate,
       difficulty_title: "中級編"
     }));
   };
@@ -210,7 +210,7 @@ export const RankingBox = memo(({
   const handleAdvanced = () => {
     setRankingState((prev) => ({
       ...prev,
-      current_top_three_array: prev.top_three_advanced,
+      current_top_ten_array: prev.top_ten_advanced,
       difficulty_title: "上級編"
     }));
   };
@@ -277,7 +277,7 @@ export const RankingBox = memo(({
         </IconButton>
       </TitleLineWrapper>
       {
-        current_top_three_array.length ?
+        current_top_ten_array.length ?
           <RankingWrapper>
             <CustomTable>
               <CustomThead>
@@ -289,7 +289,7 @@ export const RankingBox = memo(({
               </CustomThead>
               <tbody>
                 {
-                  current_top_three_array.map(({
+                  current_top_ten_array.map(({
                     game_management: { 
                       result_time 
                     }, 

--- a/frontend/src/components/Headers/Header.jsx
+++ b/frontend/src/components/Headers/Header.jsx
@@ -71,7 +71,7 @@ export const Header = memo(({
       >
         <Container maxWidth="xl">
           <Toolbar disableGutters>
-            <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'flex' } }}>
+            <Box sx={{ flexGrow: 1, display: { xs: 'inline', md: 'inline' } }}>
               <HeaderTitle />
             </Box>
             <Box sx={{ flexGrow: 0, display: { xs: 'flex', md: 'flex', lg: 'none' } }}>

--- a/frontend/src/components/Sentences/HeaderTitle.jsx
+++ b/frontend/src/components/Sentences/HeaderTitle.jsx
@@ -20,7 +20,7 @@ const MainTitleImageCover = styled.img`
   max-width: 100%;
   height: auto;
   @media (max-width: ${WIDTH.MOBILE}) {
-    width: 30%
+    width: 40%;
   };
 `;
 

--- a/frontend/src/containers/Rankings.jsx
+++ b/frontend/src/containers/Rankings.jsx
@@ -26,8 +26,8 @@ import { HTTP_STATUS_CODE } from '../constants';
 // メインのラッパー
 const MainWrapper = styled.div`
   background-color: ${COLORS.SUB};
-  padding-top: 44px;
-  padding-bottom: 36px;
+  padding-top: 3%;
+  padding-bottom: 2.65%;
 `;
 
 export const Rankings = () => {

--- a/frontend/src/containers/Rankings.jsx
+++ b/frontend/src/containers/Rankings.jsx
@@ -45,10 +45,10 @@ export const Rankings = () => {
   } = useContext(UserContext);
 
   const initialState = {
-    top_three_elementary: [],
-    top_three_intermediate: [],
-    top_three_advanced: [],
-    current_top_three_array: [],
+    top_ten_elementary: [],
+    top_ten_intermediate: [],
+    top_ten_advanced: [],
+    current_top_ten_array: [],
     difficulty_title: ""
   };
 
@@ -101,10 +101,10 @@ export const Rankings = () => {
     getRanking().then((data) => {
       setRankingState((prev) => ({
         ...prev,
-        top_three_elementary: data.top_three_elementary,
-        top_three_intermediate: data.top_three_intermediate,
-        top_three_advanced: data.top_three_advanced,
-        current_top_three_array: data.top_three_elementary,
+        top_ten_elementary: data.top_ten_elementary,
+        top_ten_intermediate: data.top_ten_intermediate,
+        top_ten_advanced: data.top_ten_advanced,
+        current_top_ten_array: data.top_ten_elementary,
         difficulty_title: "初級編"
       }));
     }).catch((e) => {
@@ -141,7 +141,7 @@ export const Rankings = () => {
       /> 
       <MainWrapper>
         <RankingBox
-          current_top_three_array={rankingState.current_top_three_array}
+          current_top_ten_array={rankingState.current_top_ten_array}
           difficulty_title={rankingState.difficulty_title}
           setRankingState={setRankingState}
         />


### PR DESCRIPTION
## 関連するissue
- ref  #164 
- resolved #164 

## 概要
以下を実行しました。
-  ランキングページをレスポンシブ対応させる。難易度毎にレスポンシブ対応させる。
-  ランキングを取得するクエリに問題がないかを見る。最適化できるかも確認する。

## 確認事項
-  ランキングページがレスポンシブ対応されている。

## 確認方法
- ランキングページにアクセスしていただけると確認できます。

## 懸念点
特になし。

## 参考記事
ゲームデータに紐づくユーザーのアバター画像を取得するときにN+1問題が発生していたので、以下の記事を参考にして解消した。
 - [Active StorageのN+1問題に対処する](https://shuttodev.hatenablog.com/entry/2019/09/10/012916)
 - [【Rails】 N+1問題をincludesメソッドで解決しよう！](https://pikawaka.com/rails/includes#%E3%83%8D%E3%82%B9%E3%83%88%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E7%8A%B6%E6%85%8B%E3%81%AEN+1%E5%95%8F%E9%A1%8C%E3%82%82includes%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%81%A7%E8%A7%A3%E6%B1%BA%E3%81%97%E3%82%88%E3%81%86)
 - [HTTP304（Not Modified）とは](https://uxmilk.jp/50715)
 - [Bulk InsertをRailsで検証してみた](https://speakerdeck.com/hasehiro25/bulk-insertworailsdejian-zheng-sitemita?slide=23)