### PR TITLE
ファイルサイズのバリデーションを作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,22 @@ class User < ApplicationRecord
   # nilの時はバリデーションをスキップする
   validates :reset_password_token, uniqueness: true, allow_nil: true
   validates :open_rank, inclusion: [true, false]
+  validate :avatar_type, :avatar_size
+
+  private
+
+  # in?に含まれていればtrueになる。含まれているのが正常
+  def avatar_type
+    if !avatar.blob.content_type.in?(%('image/jpg image/jpeg image/png'))
+      avatar.purge
+      errors.add(:avatar, 'jpegまたはpng形式でアップロードしてください')
+    end
+  end
+
+  def avatar_size
+    if avatar.blob.byte_size > 1.megabytes
+      avatar.purge
+      errors.add(:avatar, "1MB以内のファイルを選択してください")
+    end
+  end
 end

--- a/frontend/src/components/Games/AccountSettingBox.jsx
+++ b/frontend/src/components/Games/AccountSettingBox.jsx
@@ -218,7 +218,7 @@ export const AccountSettingBox = ({
         state: { display: true, success: "アカウントを更新しました。"}
       })
     ).catch((e) => {
-      if(e.response.status === HTTP_STATUS_CODE.NOT_FOUND){
+      if(e.response.status === HTTP_STATUS_CODE.BAD_REQUEST){
         dispatch({
           type: requestUserActionTyps.REQUEST_FAILURE,
           payload: {
@@ -325,7 +325,7 @@ export const AccountSettingBox = ({
               />
             </AccoutSettingButtonWrapper>
             {
-              requestUserState.errors.title === 'Record Not Found' && 
+              requestUserState.errors.title === 'Bad Request' && 
                 <SubmitErrorSentence>
                   {requestUserState.errors.detail}
                 </SubmitErrorSentence>

--- a/frontend/src/components/Games/AccountSettingBox.jsx
+++ b/frontend/src/components/Games/AccountSettingBox.jsx
@@ -245,6 +245,7 @@ export const AccountSettingBox = ({
               accept="image/*" 
               id="icon-button-file" 
               type="file" 
+              accept=".png, .jpg, .jpeg"
               onChange={(e) => handleUpload(e)}
             />
             <IconButton 


### PR DESCRIPTION
## 関連するissue
- ref  #171 
- resolved #171 

## 概要
以下を実行しました。
- ファイルサイズのバリデーションを作成する。 
- 1MB以上のファイルをアップロードした場合、エラーメッセージが表示される。

## 確認事項
-  1MB以上のファイルをアップロードしようとすると、フォームにエラーメッセージが表示される。

## 確認方法
- 1MB以上のファイルをアップロードすると確認できます。

## 懸念点
特になし。

## 参考記事
 -  [Active Storageファイルアップロード時のバリデーション設定](https://qiita.com/sdkk-rails/items/8f5c006a1f052beb91ce)
 - [Rails5 Active Storageを使って画像アップロード機能を実装する](https://midnight-engineering.hatenadiary.jp/entry/2018/09/24/012139)
 - [in?](https://apidock.com/rails/Object/in%3F)
 - [Rubyで%記法（パーセント記法）を使う](https://qiita.com/mogulla3/items/46bb876391be07921743)
 - [in?(another_object) public](https://apidock.com/rails/Object/in%3F)
 - [Rails | 数字をバイト数に変換する](https://qiita.com/Yinaura/items/4f6591df5d7c7bf68a90)
 - [instance method String#split](https://docs.ruby-lang.org/ja/latest/method/String/i/split.html)
 - [file](https://code-kitchen.dev/html/input-file/)