### PR TITLE
Add: クリアタイムのフォーマットをhh:mm:ssからmm:ssに変更した

### DIFF
--- a/frontend/src/components/Games/AccountSettingBox.jsx
+++ b/frontend/src/components/Games/AccountSettingBox.jsx
@@ -242,7 +242,6 @@ export const AccountSettingBox = ({
           />
           <CustomLabel htmlFor="icon-button-file">
             <Input 
-              accept="image/*" 
               id="icon-button-file" 
               type="file" 
               accept=".png, .jpg, .jpeg"

--- a/frontend/src/components/Games/FastAnalysisBox.jsx
+++ b/frontend/src/components/Games/FastAnalysisBox.jsx
@@ -48,7 +48,7 @@ export const FastAnalysisBox = memo(({
 
   // 今月の最速タイムを出力する処理 
   // minutesに任意の難易度の最速タイムが入っている
-  const format_fastest_time =  useMemo(() => getClearTime(0, minutes).slice(3), [minutes]);
+  const format_fastest_time =  useMemo(() => getClearTime(0, minutes), [minutes]);
 
   return (
     <>

--- a/frontend/src/components/Games/RankingBox.jsx
+++ b/frontend/src/components/Games/RankingBox.jsx
@@ -304,7 +304,7 @@ export const RankingBox = memo(({
                       <RankingDataTd>{index + 1}</RankingDataTd>
                       <TimeDataTd>
                         {
-                          getClearTime(0, result_time).slice(3)
+                          getClearTime(0, result_time)
                         }
                       </TimeDataTd>
                       <HunterDataTd>

--- a/frontend/src/functions/getClearTime.js
+++ b/frontend/src/functions/getClearTime.js
@@ -1,5 +1,9 @@
 // タイムを計算してhh:mm:ssのフォーマットで出力する関数
 // マイページで使う場合、第1引数を0にする
+// hhは無くても良いので、やっぱり消す
+// hh:mm:ssがmm:ss表記になる
+// const hours=Math.floor(milli_sec/1000/60/60)%24;
+// const hh = ('0' + hours).slice(-2);
 export const getClearTime = (
   game_start_time, 
   game_end_time
@@ -7,10 +11,8 @@ export const getClearTime = (
   const milli_sec = game_end_time - game_start_time;
   const sec = Math.floor(milli_sec/1000) % 60;
   const min=Math.floor(milli_sec/1000/60) % 60;
-  const hours=Math.floor(milli_sec/1000/60/60)%24;
 
-  const hh = ('0' + hours).slice(-2);
   const mm = ('0' + min).slice(-2);
   const ss = ('0' + sec).slice(-2);
-  return `${hh}:${mm}:${ss}`;
+  return `${mm}:${ss}`;
 };


### PR DESCRIPTION
## 関連するissue
- ref  #175 
- resolved #175 

## 概要
以下を実行しました。
-  クリアタイムの表記をhh:mm:ssから、mm:ssに変更する。
-  ランキングとマイページのsplitを消す。

## 確認事項
-  クリアタイムの表記をhh:mm:ssから、mm:ssに変更されている。
-  ランキングとマイページのsplitを消されている。

## 確認方法
- ランキングページ、マイページ、クリアタイムモーダルから確認できます。

## 懸念点
特になし。

## 参考記事
特になし。
