### PR TITLE
Add: React Routerのメソッドをprivateから外した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,15 @@ class ApplicationController < ActionController::API
   protect_from_forgery with: :exception
   before_action :require_login
 
+  # React Routerを本番環境で動かすために必要なメソッド
+  # ルーティングにこのメソッドが実行されるように定義した
+  # fallback_index_htmlメソッドによりpublic/index.htmlが返される
+  def fallback_index_html
+    respond_to do |format|
+      format.html { render body: Rails.root.join('public/index.html').read }
+    end
+  end
+
   private
 
     def not_authenticated
@@ -19,10 +28,4 @@ class ApplicationController < ActionController::API
       response.set_header('X-CSRF-Token', form_authenticity_token)
     end
 
-    # React Routerを本番環境で動かすために必要なメソッド
-    def fallback_index_html
-      respond_to do |format|
-        format.html { render body: Rails.root.join('public/index.html').read }
-      end
-    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
   # React Routerを本番環境で動かす為に必要なルーティング
   # railsのルーティングについて書いている部分より下に追記する
+  # Railsのルートは上から順にマッチするかを判定していく
   get '*path', to: 'application#fallback_index_html', constraints: ->(request) {
     !request.xhr? && request.format.html?
   }


### PR DESCRIPTION
## 関連するissue
一旦なし。

## 概要
以下を実行しました。
- fallback_index_htmlメソッドをprivateの外側に再定義した。
 
## 確認事項
- fallback_index_htmlがprivateの外側に存在する。

## 確認方法
コミット履歴から確認できます。

## 懸念点
特になし。

## 参考記事
特になし。