### PR TITLE
Add: React Routerのコンポーネントをフッターとランキングに追加した

### DIFF
--- a/frontend/src/components/Footers/Footer.jsx
+++ b/frontend/src/components/Footers/Footer.jsx
@@ -9,6 +9,9 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 
+// BaseLink
+import { BaseLink } from '../shared_style.js';
+
 const FooterWrapper = styled.div`
   background-color: ${COLORS.BROWN};
 `;
@@ -27,7 +30,8 @@ export const Footer = () => {
                 <Button
                   key="1"
                   sx={{ my: 2, color: 'white', display: 'block' }}
-                  href='/policy'
+                  component={BaseLink}
+                  to="/policy"
                 >
                   利用規約
                 </Button>
@@ -36,7 +40,8 @@ export const Footer = () => {
                 <Button
                   key="1"
                   sx={{ my: 2, color: 'white', display: 'block' }}
-                  href='/privacy-policy'
+                  component={BaseLink}
+                  to="/privacy-policy"
                 >
                   プライバシーポリシー
                 </Button>

--- a/frontend/src/components/Headers/Header.jsx
+++ b/frontend/src/components/Headers/Header.jsx
@@ -139,7 +139,8 @@ export const Header = memo(({
               <Button
                 key="1"
                 sx={{ my: 2, color: 'white', display: 'block', width: '6vw' }}
-                href='/rankings'
+                component={BaseLink}
+                to="/rankings"
               >
                 ランキング
               </Button>
@@ -150,7 +151,15 @@ export const Header = memo(({
                   <Box sx={{ flexGrow: 0, display: { xs: 'none', md: 'none', lg: 'flex' } }}>
                     <Button
                       key="1"
-                      sx={{ my: 2, color: 'white', display: 'block', width: '6vw' }}
+                      sx={{ 
+                        my: 2, 
+                        color: 'white', 
+                        display: 'block', 
+                        width: '6vw',
+                        '&:hover': {
+                          opacity: 0.7
+                        }
+                      }}
                       onClick={() => onClickLink("login")}
                     >
                       ログイン
@@ -159,7 +168,15 @@ export const Header = memo(({
                   <Box sx={{ flexGrow: 0, display: { xs: 'none', md: 'none', lg: 'flex' } }}>
                     <Button
                       key="1"
-                      sx={{ my: 2, color: 'white', display: 'block', width: '7vw' }}
+                      sx={{ 
+                        my: 2, 
+                        color: 'white', 
+                        display: 'block', 
+                        width: '7vw', 
+                        '&:hover': {
+                          opacity: 0.7
+                        }
+                      }}
                       onClick={() => onClickLink("signUp")}
                     >
                       新規会員登録


### PR DESCRIPTION
## 関連するissue
- ref  #198 
- resolved #198 

## 概要
以下を実行しました。
 - ヘッダーとフッターのhrefをLinkコンポーネントに書き換えた。

## 確認事項
- hrefからLinkコンポーネントに変化している。

## 確認方法
コミット履歴から確認できます。

## 懸念点
特になし。

## 参考記事
 - [Array values](https://mui.com/system/the-sx-prop/#array-values)
 - [Material-UI の Button と React Router の Link を組み合わせる](https://tnakamura.hatenablog.com/entry/2020/08/12/material-ui-button-react-router-link)
