### PR TITLE
Feature/improvement ##204

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::API
   include ActionController::MimeResponds
   protect_from_forgery with: :exception
   before_action :require_login
+  skip_before_action :require_login, only: :fallback_index_html
 
   # React Routerを本番環境で動かすために必要なメソッド
   # ルーティングにこのメソッドが実行されるように定義した

--- a/frontend/src/components/Sentences/CreateAccountSentence.jsx
+++ b/frontend/src/components/Sentences/CreateAccountSentence.jsx
@@ -26,11 +26,11 @@ export const CreateAccountSentence = () => {
       <CreateAccountSentenceWrapper>
         <CreateAccountAgreeSentenceWrapper>
           アカウントを作成することにより、
-          <BlueBaseLink to={'/policy'} target="_blank" rel="noopener noreferrer">
+          <BlueBaseLink to="/policy" target="_blank" rel="noopener noreferrer">
             利用規約
           </BlueBaseLink>
           および
-          <BlueBaseLink to={'/privacy-policy'} target="_blank" rel="noopener noreferrer">
+          <BlueBaseLink to="/privacy-policy" target="_blank" rel="noopener noreferrer">
             プライバシーポリシー
           </BlueBaseLink>
           に同意するものとします。


### PR DESCRIPTION
## 関連するissue
- ref  #204 
- resolved #204 

## 概要
以下を実行しました。
- 別タブでページが開かないのは、fall_back_index.htmlにbefore_action: require_loginが効いているのが原因かと思ったので、skip_before_action :require_login only: :fall_back_index.htmlを定義しました。
- 平均正解数は重くなりそうなので、別issueに切り出しました。
 
## 確認事項
- コミット履歴にrequire_loginが反映されている。

## 確認方法
コミット履歴から確認できます。

## 懸念点
skip_before_action :require_login only: :fall_back_index.htmlでちゃんとした挙動になるかは不明なので、デプロイ後に確認します。もし、ダメなら再度issueを作ります。

## 参考記事

