### PR TITLE
Fix: ランキングのロジックを修正した

### DIFF
--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -4,9 +4,9 @@ class Api::V1::RankingsController < ApplicationController
 
   # 自分のランクを表示する部分は一旦保留。かなりムズイ
   def index
-    top_ten_elementary = get_top_ten('elementary')
-    top_ten_intermediate = get_top_ten('intermediate')
-    top_ten_advanced = get_top_ten('advanced')
+    top_ten_elementary = get_top_ten(:elementary)
+    top_ten_intermediate = get_top_ten(:intermediate)
+    top_ten_advanced = get_top_ten(:advanced)
     render json: {
       top_ten_elementary: top_ten_elementary,
       top_ten_intermediate: top_ten_intermediate,
@@ -16,30 +16,48 @@ class Api::V1::RankingsController < ApplicationController
 
   private
 
-    # open_rankがtrueのユーザーidを全て取得する
-    # そのidを外部キーにもつゲームデータを取得する
-    # whereのハッシュのバリューに配列を指定すると、in句と同じ意味になる
-    # orderは、デフォルトで昇順である
-    # そのため、最も早いゲームデータがレコードの一番上にくる
-    # to_aメソッドで、ActiveRecord_Relationクラスのオブジェクトを、
-    # Arrayクラスのオブジェクトに変換する
-    # 複数のゲームマネジメントに対して1人のユーザーが存在するので(N対1)
-    # eager_loadで左外部結合をした。
-    # ユーザー1人に対して、プロフィール画像が1つ存在しているので、
-    # そのプロフィール画像もeager_loadで取得する
-    # おかげで、1回のクエリで上位3つの速さのゲームデータ, ユーザー, 画像を取得できる
+    # joinsメソッドでusersテーブルと内部結合する
+    # groupメソッドでusersテーブルのidに対してグループ化する(nameでグループ化すると、同じ名前のユーザーがいる為)
+    # groupメソッドを集計関数と一緒ではなく単体で使うと、指定したカラムでレコードがグループ化され、
+    # グループ毎に1番小さいidのレコードが表示される(裏側では全てのレコードが指定したカラムでグループ化されている)
+    # whereで取得するレコードに条件を設定する
+    # orderメソッドでresult_timeを小さい順にする(デフォルトで昇順。グループ化と検索の後に実行される)
+    # limitで取得するレコード数を制限する
+    # selectメソッドで取得するカラムを指定する。selectがないとjoinsはGameManagementの全カラムのデータを返す
+    # テーブルの指定→結合(joins)→取得条件(where)→グループ化(group)→検索(select)→順序(order)→LIMIT(limit)
+    # の順番でSQLが実行される
+    # その為、orderを実行した時点で、groupの返す1件がグループ毎のidが一番小さいレコードではなく、
+    # グループ毎のresult_timeが一番小さいレコードを返す
+    # (グループ毎に、result_timeが一番小さいレコードが昇順になっているため)
+    # その為、集計関数でデータを作らなくても、最小値のレコードは取得できる
+    # と思ったのだが、group化した時にMINを実行しないと、最小値の順になっていなかったので、
+    # MINを追加しました。MINを追加したらちゃんと最小順になった
     def get_top_ten(difficulty)
-      top_ten_array = GameManagement.where(difficulty: difficulty, game_result: :win,
-                                           user_id: User.where(open_rank: true).pluck(:id)).order(:result_time).limit(10)
+      top_ten_array = GameManagement.joins(:user)
+                                    .group('users.id')
+                                    .where(
+                                      difficulty: difficulty,
+                                      game_result: :win,
+                                      user_id: User.where(open_rank: true).pluck(:id)
+                                    )
+                                    .order(:result_time)
+                                    .limit(10)
+                                    .select(
+                                      "game_managements.*,
+                                       users.name,
+                                       users.rank,
+                                       users.active_title,
+                                       MIN(game_managements.result_time) AS min_result_time"
+                                    )
                                     .eager_load(user: { avatar_attachment: :blob }).to_a
-                                    .map do |game_management|
+                                    .map do |data|
         {
-          game_management: game_management,
+          game_management: data,
           user: {
-            name: game_management.user[:name],
-            rank: game_management.user[:rank],
-            active_title: game_management.user[:active_title],
-            image: game_management.user.avatar.attached? ? url_for(game_management.user.avatar) : nil
+            name: data.name,
+            rank: data.rank,
+            active_title: User.active_titles.key(data.active_title),
+            image: data.user.avatar.attached? ? url_for(data.user.avatar) : nil
           }
         }
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,5 +28,4 @@ class ApplicationController < ActionController::API
     def set_csrf_token_header
       response.set_header('X-CSRF-Token', form_authenticity_token)
     end
-
 end


### PR DESCRIPTION
## 関連するissue
- ref  #237 
- resolved #237

## 概要
以下を実行しました。
- ランキングのユーザーが重複する問題を解決しました。そのユーザーの最小タイムが表示されるようにロジックを書き換えました。
 
## 確認事項
-  2回以上ゲームプレイしても、同じユーザーがランキングに登場しない。

## 確認方法
ゲームプレイ後、ランキングを確認していただくようお願いします。

## 懸念点
多分大丈夫だと思いますが、もしかしたら何かしらの予期せぬ不具合が発生している可能性があります。判明次第随時対応します。

## 参考記事
 - [【Rails】 groupメソッドの使い方とは？仕組みを図解で丁寧に解説！](https://pikawaka.com/rails/group)
 - [【Rails】 joinsメソッドの使い方 ~ テーブル結合からネストまで学ぶ](https://pikawaka.com/rails/joins#select%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%81%A7%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B%E3%83%AC%E3%82%B3%E3%83%BC%E3%83%89%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B)
 - [【Rails】Rubocopの自動修正コマンド「rubocop -a」と「rubocop -A」の違い](https://techtechmedia.com/auto-correct-rubocop/)
 - [ハッシュで値からキーを取得する](https://qiita.com/torshinor/items/8f707fa49542a8b0171e)
 - [全体実行順序の確認](https://prog-8.com/slides?displayed_id=6301&lesson=147%2C275%2C180%2C319&word=)