### PR TITLE
Add: ストレージ先をamazonからlocalに設定し直した

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
## 関連するissue
- ref  #251 
- resolved #251 

## 概要
以下を実行しました。
- 本番環境のストレージをlocalに設定
 
## 確認事項
-  amazonからlocalに変更してある。

## 確認方法
- 差分ファイルで確認できます。

## 懸念点
これでもし、本番環境のmigrateが成功した場合、ストレージをまたamazonにして、もう一度pushする

## 参考記事
特になし。
