### PR TITLE
Add: googleサーチコンソールのタグをheadタグに追加した

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "react-circular-progressbar": "^2.0.4",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.21.0",
-    "react-id-swiper": "^4.0.0",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
     "react-scroll": "^1.8.4",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Regex Hunting</title>
+    <meta name="google-site-verification" content="BS2jEGnW4LOjyjzhClEqtyEfbjkdr11d4i4WGhje-qY" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9581,13 +9581,6 @@ react-hook-form@^7.21.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.21.0.tgz#f6f0311295b83ca768873ca9f2a787ff1525f591"
   integrity sha512-aekCf+dedYFIg+7nCK2acMvZ+s6Ohw2I7UNQ+zNIadBl1SoXow2Tl6c3F49xF8GFCdn5jeK43JHH26rmtdRyLQ==
 
-react-id-swiper@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-id-swiper/-/react-id-swiper-4.0.0.tgz#eed938c5a4bf464a5cd7316a1bf6778581f47f2f"
-  integrity sha512-BFY8VQYgc1ECkT1Ek6MYSF8MADjWYZctdeRlMA202mjGcdjq1Bugfhg207KHTjGWKWZlY/7/nxFShqQo74RslA==
-  dependencies:
-    object-assign "^4.1.1"
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 関連するissue
- ref  #243 
- resolved #243 

## 概要
以下を実行しました。
- react-id-swiperをアンインストールした
- googleサーチコンソールのタグをheadタグに追加した
 
## 確認事項
-  googleサーチコンソールを使える。

## 確認方法
本番環境で確認できます。

## 懸念点
特になし。

## 参考記事
- [サーチコンソールのプロパティタイプの選び方](https://www.cn-door.com/blog/1792/)
- [プロパティタイプはどっち？初心者のためのサーチコンソールの登録方法](https://design.coeure.co.jp/blog/analysis/searchconsole/setting_200323)
