### PR TITLE
Add: roleのenumをusersテーブルとUserモデルに定義した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
     語り継がれし英雄: 7
   }
 
+  enum role: {
+    general: 0,
+    admin: 250
+  }
+
   validates :name, presence: true, length: { maximum: 10 }
 
   REGEX_PATTERN = /\A[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]{1,}.[A-Za-z0-9]{1,}\z/

--- a/db/migrate/20220121114545_sorcery_core.rb
+++ b/db/migrate/20220121114545_sorcery_core.rb
@@ -8,6 +8,7 @@ class SorceryCore < ActiveRecord::Migration[6.0]
       t.integer :temporary_experience, null: false, default: 0
       t.boolean :open_rank, null: false, default: true
       t.integer :active_title, null: false, default: 0
+      t.integer :role, null: false, default: 0
 
       # sorcery
       t.string :email, null: false, index: { unique: true }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2022_01_24_120114) do
     t.integer "temporary_experience", default: 0, null: false
     t.boolean "open_rank", default: true, null: false
     t.integer "active_title", default: 0, null: false
+    t.integer "role", default: 0, null: false
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"


### PR DESCRIPTION
## 関連するissue
- ref  #242 
- resolved #242 

## 概要
以下を実行しました。
- usersテーブルにroleカラムを追加した。
- Userモデルにroleのenumを追加した。
 
## 確認事項
- usersテーブルにroleカラムが追加されている。
- Userモデルにroleのenumが追加されている。 

## 確認方法
差分ファイルから確認できます。

## 懸念点
一応、影響範囲は確認して大丈夫だったが、もし何か影響があるなら再度修正する。このカラム自体、インスタンスを生成後に何かいじるということはないので、影響範囲はないと思われる(ちゃんと全てのコントローラも確認した)。

## 参考記事
特になし。
