### PR TITLE
Add: Googleアナリティクスを設定した

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-REACT_APP_SERVER_URL=http://localhost:3000
+REACT_APP_SERVER_URL='http://localhost:3000'

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,3 @@
-REACT_APP_SERVER_URL=https://www.regex-hunting.com
+REACT_APP_SERVER_URL='https://www.regex-hunting.com'
+G_TRACKING_Id='G-NN0J604Q3E'
+UA_TRACKING_Id='UA-224030183-1'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import React from "react";
 // React Router
 import {
   BrowserRouter as Router,
-  Routes,
   Route,
 } from "react-router-dom";
 
@@ -25,15 +24,18 @@ import ScrollToTop from './scroll/ScrollToTop';
 // Provider
 import { UserProvider } from "./context/UserProvider";
 
+// Analyticsコンポーネント
+// 内部にGoogleAnalyticsに関する処理と、Routesコンポーネントが記述されている
+import { Analytics } from './analytics/Analytics';
+
 // App Component
 function App(): JSX.Element {
-
   return (
     <React.StrictMode>
       <UserProvider>
         <Router>
           <ScrollToTop />
-          <Routes>
+          <Analytics>
             {/* LPページ */}
             <Route
               path="/"
@@ -107,7 +109,7 @@ function App(): JSX.Element {
               path="/*"
               element={<NotFoundPage />}
             />
-          </Routes>
+          </Analytics>
         </Router>
       </UserProvider>
     </React.StrictMode>

--- a/frontend/src/analytics/Analytics.tsx
+++ b/frontend/src/analytics/Analytics.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+// React Router
+import { Routes } from "react-router-dom";
+// Googleアナリティクス
+import { useTracking } from '../hooks/useTracking';
+
+export const Analytics = ({children}: {children: ReactNode}) => {
+  useTracking(process.env.G_TRACKING_Id);
+  useTracking(process.env.UA_TRACKING_Id);
+
+  return (
+    <Routes>
+      {children}
+    </Routes>
+  );
+}

--- a/frontend/src/hooks/useTracking.ts
+++ b/frontend/src/hooks/useTracking.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+declare global {
+  interface Window {
+    gtag?: (
+      key: string,
+      trackingId: string,
+      config: { page_path: string }
+    ) => void;
+  }
+}
+
+export const useTracking = (
+  trackingId: string | undefined = process.env.G_TRACKING_Id
+) => {
+  let location = useLocation();
+
+  useEffect(() => {
+    if (!window.gtag) return;
+    if (!trackingId) return;
+    window.gtag("config", trackingId, { page_path: location.pathname });
+  }, [trackingId, location]);
+};


### PR DESCRIPTION
## 関連するissue
- ref  #241 
- resolved #241 
## 概要
Googleアナリティクスを設定しました！
 
## 確認事項
Googleアナリティクスが機能する

## 確認方法
デプロイ後に確認できます。

## 懸念点
特になし。

## 参考記事
- [create-react-appで独自の環境変数を読み込む](https://qiita.com/zgmf_mbfp03/items/008436c5749d65f96e55)
- [Googleアナリティクスの設定方法](https://www.atoj.co.jp/atoj-info/detail/21)
- [GoogleアナリティクスのトラッキングID発行・設定方法](https://www.gpol.co.jp/blog/100)
- [リアクトルーター](https://blog.uhy.ooo/entry/2020-06-10/react-router-location/)
- [TypeError: window.gtag is not a function](https://stackoverflow.com/questions/62791299/typeerror-window-gtag-is-not-a-function)
- [リアクトルーター内でのアナリティクスの導入](https://remix.run/blog/react-router-v6)
- [リアクトルーターの導入](https://zenn.dev/mamezou/articles/4d0d7b79b639d5)
