### PR TITLE
Add: Googleで続けるを赤にした

### DIFF
--- a/frontend/src/components/Dialogs/LoginDialog.tsx
+++ b/frontend/src/components/Dialogs/LoginDialog.tsx
@@ -250,7 +250,7 @@ export const LoginDialog = ({
           <OrDirectionSentence />
           <OAuthLoginButton
             url={googleOAuth}
-            color={COLORS.PINK}
+            color={COLORS.RED}
             type="Google"
           />
           <OAuthLoginButton

--- a/frontend/src/components/Dialogs/SignUpDialog.tsx
+++ b/frontend/src/components/Dialogs/SignUpDialog.tsx
@@ -337,7 +337,7 @@ export const SignUpDialog = ({
           <OrDirectionSentence />
           <OAuthLoginButton
             url={googleOAuth}
-            color={COLORS.PINK}
+            color={COLORS.RED}
             type="Google"
           />
           <OAuthLoginButton


### PR DESCRIPTION
## 関連するissue
- ref  #299 
- resolved #299 

## 概要
以下を実行しました。
- googleで続けるを赤にする。
 
## 確認事項
- googleで続けるが赤になっている。

## 確認方法
ログインモーダルと新規会員登録モーダルから確認できます。

## 懸念点
特になし。

## 参考記事
特になし。
