### PR TITLE
Add: Twitterカードの内容を追加しました

### DIFF
--- a/frontend/src/components/Dialogs/GameClearDialog.tsx
+++ b/frontend/src/components/Dialogs/GameClearDialog.tsx
@@ -126,7 +126,6 @@ const ColorTimeSpan = styled.span<{milliSec: number}>`
   color: ${({ milliSec }) => milliSec < 60000 && COLORS.RED }
 `;
 
-
 export const GameClearDialog = ({
   isOpen,
   difficulty,
@@ -232,6 +231,7 @@ export const GameClearDialog = ({
               rankUp={rankUp}
               rank={rank}
               clearTime={shareClearTime}
+              hasUser={hasUser}
             />
             {
               hasUser ?

--- a/frontend/src/components/Dialogs/GameOverDialog.tsx
+++ b/frontend/src/components/Dialogs/GameOverDialog.tsx
@@ -198,6 +198,8 @@ export const GameOverDialog = ({
               difficulty={difficulty}
               gameResult={gameResult}
               rankUp={rankUp}
+              hasUser={hasUser}
+              rank={rank}
             />
             {
               hasUser ?

--- a/frontend/src/components/Dialogs/RankUpDialog.tsx
+++ b/frontend/src/components/Dialogs/RankUpDialog.tsx
@@ -112,6 +112,7 @@ type RankUpDialogArg = {
   rankUp: true;
   difficulty: string | undefined;
   gameResult: "" | "progress" | "win" | "lose";
+  hasUser: boolean;
 };
 
 // gameStateのrankUpがtrueの時に開くモーダル
@@ -125,7 +126,8 @@ export const RankUpDialog = ({
   setGameState,
   rankUp,
   difficulty,
-  gameResult
+  gameResult,
+  hasUser
 }: RankUpDialogArg): JSX.Element => {
 
   // ゲームクリア時の音
@@ -184,6 +186,7 @@ export const RankUpDialog = ({
               difficulty={difficulty}
               gameResult={gameResult}
               rank={rank}
+              hasUser={hasUser}
             />
           </ButtonsWrapper>
         </CustomDialogContent>

--- a/frontend/src/components/Games/QuestionBlock.tsx
+++ b/frontend/src/components/Games/QuestionBlock.tsx
@@ -13,6 +13,8 @@ import { getExperience } from '../../functions/getExperience';
 // サニタイズ用のライブラリをインポートしてくる
 import DOMPurify from "dompurify";
 
+import { getJpDifficulty } from '../../functions/getJpDifficulty';
+
 // gameStateの型
 import { GameState, SetGameState } from '../../types/containers/games';
 
@@ -121,25 +123,6 @@ export const QuestionBlock = ({
   temporaryExperience,
   clickMetaOpen
 }: QuestionBlockArg): JSX.Element => {
-
-  // 難易度を日本語に変換する関数
-  const getJpDifficulty = (difficulty: string | undefined): string | undefined => {
-    let jpDifficulty;
-    switch (difficulty){
-      case 'elementary':
-        jpDifficulty = '初級';
-        break;
-      case 'intermediate':
-        jpDifficulty = '中級';
-        break;
-      case 'advanced':
-        jpDifficulty = '上級';
-        break;
-      default:
-        console.log('エラーが起きました');
-    }
-    return jpDifficulty;
-  };
 
   // 難易度毎のモンスターからダメージを喰らう時のセンテンス
   const getDamageSentence = (difficulty: string | undefined) => {

--- a/frontend/src/containers/Games.tsx
+++ b/frontend/src/containers/Games.tsx
@@ -745,6 +745,7 @@ export const Games = (): JSX.Element => {
                   difficulty={difficulty}
                   gameResult={gameState.gameResult}
                   rankUp={gameState.rankUp}
+                  hasUser={gameState.hasUser}
                 />
             }
             {

--- a/frontend/src/functions/getJpDifficulty.ts
+++ b/frontend/src/functions/getJpDifficulty.ts
@@ -1,0 +1,15 @@
+export const getJpDifficulty = (difficulty: string | undefined): string | undefined => {
+  let jpDifficulty;
+  switch (difficulty){
+    case 'elementary':
+      jpDifficulty = '初級';
+      break;
+    case 'intermediate':
+      jpDifficulty = '中級';
+      break;
+    case 'advanced':
+      jpDifficulty = '上級';
+      break;
+  }
+  return jpDifficulty;
+};


### PR DESCRIPTION
## 関連するissue
- ref  #302 
- resolved #302 

## 概要
 Twitterカードの内容を追加しました。

## 確認事項
 Twitterカードの内容を追加されている。

## 確認方法
ゲーム結果をシェアしていただけると確認できます。

## 懸念点
特になし。

## 参考記事
 - [ASCII文字とURLエンコードの対応表](https://www.seil.jp/doc/index.html#tool/url-encode.html)
