### PR TITLE
Fix: ゲーム画面のレイアウトが崩れる問題を解決した

### DIFF
--- a/frontend/src/components/Footers/GameFooter.tsx
+++ b/frontend/src/components/Footers/GameFooter.tsx
@@ -13,9 +13,9 @@ import { SetGameState } from '../../types/containers/games';
 
 const FooterWrapper = styled.div`
   background-color: ${COLORS.BROWN};
-  height: 8.7vh;
   display: flex;
   align-items: center;
+  width: 100%;
 `;
 
 const ModalLinkBlock = styled.div`
@@ -27,7 +27,7 @@ const ModalLinkBlock = styled.div`
   color: ${COLORS.WHITE};
   font-size: 0.9em;
   margin-left: 6%;
-  width: 9vw;
+  width: 10vw;
 `;
 
 // GameFooterの引数の型

--- a/frontend/src/components/Games/AdvancedMonster.tsx
+++ b/frontend/src/components/Games/AdvancedMonster.tsx
@@ -75,7 +75,7 @@ const HpGageWrapper = styled.div<{firstAppearance: boolean}>`
 const InnerHpGageWrapper = styled.div<{monsterHp: number, monsterMaxHp: number}>`
   width: ${({ monsterHp, monsterMaxHp }) => `${100 * (monsterHp / monsterMaxHp)}%`};
   transition: 0.5s;
-  height: 1.8vh;
+  height: 15px;
   border-radius: 3px;
   background-color: ${({ monsterHp }) => handleColorType(monsterHp)};
   background-image: -webkit-linear-gradient(transparent 0%,rgba(255,255,255,.3) 50%,transparent 50%,rgba(0,0,0,.1) 100%);

--- a/frontend/src/components/Games/ElementaryMonster.tsx
+++ b/frontend/src/components/Games/ElementaryMonster.tsx
@@ -58,10 +58,11 @@ const HpGageWrapper = styled.div<{firstAppearance: boolean}>`
   margin: 0 auto;
 `;
 
+// レイアウト崩れるから、heightは15pxにした
 const InnerHpGageWrapper = styled.div<{monsterHp: number, monsterMaxHp: number}>`
   width: ${({ monsterHp, monsterMaxHp }) => `${100 * (monsterHp / monsterMaxHp)}%`};
   transition: 0.5s;
-  height: 1.8vh;
+  height: 15px;
   border-radius: 3px;
   background-color: ${({ monsterHp }) => handleColorType(monsterHp)};
   background-image: -webkit-linear-gradient(transparent 0%,rgba(255,255,255,.3) 50%,transparent 50%,rgba(0,0,0,.1) 100%);

--- a/frontend/src/components/Games/HpGage.tsx
+++ b/frontend/src/components/Games/HpGage.tsx
@@ -7,12 +7,14 @@ import { COLORS } from '../../style_constants';
 // handleColorType
 import { handleColorType } from '../../functions/handleColorType';
 
+// ここのheightは固定しないとダメ
+// vhにすると、画面の高さによってデカくなる。
 const HpGageWrapper = styled.div`
   background-color: ${COLORS.GAGE_GRAY};
   border-radius: 0 0 3px 3px;
   width: 100%;
   display: flex;
-  height: 3.9vh;
+  height: 30px;
   box-sizing: border-box;
   border-left: 5px solid;
   border-right: 5px solid;

--- a/frontend/src/components/Games/IntermediateMonster.tsx
+++ b/frontend/src/components/Games/IntermediateMonster.tsx
@@ -60,7 +60,7 @@ const HpGageWrapper = styled.div<{firstAppearance: boolean}>`
 const InnerHpGageWrapper = styled.div<{monsterMaxHp: number, monsterHp: number}>`
   width: ${({ monsterHp, monsterMaxHp }) => `${100 * (monsterHp / monsterMaxHp)}%`};
   transition: 0.5s;
-  height: 1.8vh;
+  height: 15px;
   border-radius: 3px;
   background-color: ${({ monsterHp }) => handleColorType(monsterHp)};
   background-image: -webkit-linear-gradient(transparent 0%,rgba(255,255,255,.3) 50%,transparent 50%,rgba(0,0,0,.1) 100%);

--- a/frontend/src/components/Games/QuestionBlock.tsx
+++ b/frontend/src/components/Games/QuestionBlock.tsx
@@ -18,10 +18,11 @@ import { getJpDifficulty } from '../../functions/getJpDifficulty';
 // gameStateの型
 import { GameState, SetGameState } from '../../types/containers/games';
 
+// ここをpx指定しないと崩れる
 const QuestionBlockWrapper = styled.div`
   background-color: ${COLORS.SUB};
   border-radius: 3px;
-  height: 13.4vh;
+  height: 108px;
   margin: 0 auto;
   width: 60%;
   box-shadow: 0 4px 6px rgba(0,0,0,0.2);

--- a/frontend/src/components/Games/RankingBox.tsx
+++ b/frontend/src/components/Games/RankingBox.tsx
@@ -239,6 +239,7 @@ const HunterTableTitleDataTd = styled.td`
 const NotDescriptionWrapper = styled(DescriptionWrapper)`
 `;
 
+// ここはvhで大丈夫
 const NotRankingWrapper = styled(RankingWrapper)`
   width: 100%;
   height: 59.1vh;

--- a/frontend/src/components/Games/TimeGage.tsx
+++ b/frontend/src/components/Games/TimeGage.tsx
@@ -11,12 +11,14 @@ import { calculateDamage } from '../../functions/calculateDamage';
 
 import { GameState, SetGameState } from '../../types/containers/games';
 
+// ここのheightは固定しないとダメ
+// vhにすると、画面の高さによってデカくなる。
 const TimeGageWrapper = styled.div`
   background-color: ${COLORS.GAGE_GRAY};
   border-radius: 10px 10px 0 0;
   width: 100%;
   display: flex;
-  height: 4.6vh;
+  height: 35px;
   box-sizing: border-box;
   border: 5px solid;
   border-color: ${COLORS.GAGE_GRAY};

--- a/frontend/src/containers/Games.tsx
+++ b/frontend/src/containers/Games.tsx
@@ -72,7 +72,7 @@ const MainContentWrapper = styled.div`
 const BackGroundImageCover = styled.img`
   position: absolute;
   width: 100%;
-  height: 80vh;
+  height: 85vh;
   top: 0;
   left: 0;
   right: 0;
@@ -147,6 +147,14 @@ const CodeBlockWrapper = styled.div`
 
 // GageBlockWrapperコンポーネント
 const GageBlockWrapper = styled.div`
+  width: 100%;
+`;
+
+// この中にゲージブロックラッパーとゲームフッターを入れることによて、
+// 画面最下部に固定する。
+const BottomWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
   width: 100%;
 `;
 
@@ -632,28 +640,30 @@ export const Games = (): JSX.Element => {
                     clickMetaOpen={gameState.clickMetaOpen}
                   />
                 </CodeBlockWrapper>
-                <GageBlockWrapper>
-                  <TimeGage
-                    gameState={gameState}
-                    setGameState={setGameState}
-                    timeActive={gameState.timeActive}
-                    monsterAttack={gameState.monsterAttack}
-                    userDefence={gameState.userDefence}
-                    userHp={gameState.userHp}
-                    sentenceNum={gameState.sentenceNum}
-                    clickDescriptionOpen={gameState.clickDescriptionOpen}
-                    clickMetaOpen={gameState.clickMetaOpen}
-                  />
-                  <HpGage
-                    userHp={gameState.userHp}
-                    userMaxHp={gameState.userMaxHp}
-                  />
-                </GageBlockWrapper>
               </MainGameContentWrapper>
             </MainContentWrapper>
-            <GameFooter
-              setGameState={setGameState}
-            />
+            <BottomWrapper>
+              <GageBlockWrapper>
+                <TimeGage
+                  gameState={gameState}
+                  setGameState={setGameState}
+                  timeActive={gameState.timeActive}
+                  monsterAttack={gameState.monsterAttack}
+                  userDefence={gameState.userDefence}
+                  userHp={gameState.userHp}
+                  sentenceNum={gameState.sentenceNum}
+                  clickDescriptionOpen={gameState.clickDescriptionOpen}
+                  clickMetaOpen={gameState.clickMetaOpen}
+                />
+                <HpGage
+                  userHp={gameState.userHp}
+                  userMaxHp={gameState.userMaxHp}
+                />
+              </GageBlockWrapper>
+              <GameFooter
+                setGameState={setGameState}
+              />
+            </BottomWrapper>
             {
               gameState.gameDescriptionOpen && difficulty === 'elementary' &&
                 <ElementaryGameDescriptionDialog


### PR DESCRIPTION
## 関連するissue
- ref  #296 
- resolved #296 

## 概要
ゲーム画面のレイアウトが崩れる問題を解決しました。
 
## 確認事項
画面を縦長にしても、レイアウトが崩れない。

## 確認方法
実際にゲームをしていただけると確認できます。

## 懸念点
バック画像はvhで指定したが、もしかしたら伸びない可能性がある。そこは適宜対応していく。

## 参考記事
特になし。
