### PR TITLE
Add: oauthsコントローラにデバッグのロジックを追加した

### DIFF
--- a/app/controllers/api/v1/oauths_controller.rb
+++ b/app/controllers/api/v1/oauths_controller.rb
@@ -11,7 +11,11 @@ class Api::V1::OauthsController < ApplicationController
   def callback
     provider = params[:provider]
 
+    # ログ1
+    logger.debug "①providerの値: #{provider}"
     if user = login_from(provider)
+     # ログ2
+      logger.debug "②if文true時のuser: #{user&.inspect}"
       render json: {
         session: true,
         user: User.handle_profile_user_serializer(user, user.avatar.attached? ? url_for(user.avatar) : nil)
@@ -19,15 +23,29 @@ class Api::V1::OauthsController < ApplicationController
     else
       begin
         user = create_from(provider)
+
+        # ログ3
+        logger.debug "③if文false時のuser: #{user&.inspect}"
         reset_session
         auto_login(user)
+
+        # ログ4 current_user
+        logger.debug "④if文false時のcurrent_userの値: #{current_user&.inspect}"
         current_user.release_new_title(Title.find_by(name: current_user[:active_title])[:id])
+
+        # ログ5
+        logger.debug "⑤if文false時のcurrent_user.release_titlesの値: #{current_user&.release_titles&.inspect}"
         current_user.save!
         render json: {
           session: true,
           user: User.handle_profile_user_serializer(current_user, current_user.avatar.attached? ? url_for(current_user.avatar) : nil)
         }, status: :ok
       rescue StandardError => e
+        # ログ6
+        logger.debug "⑥begin内でエラーが出たので、rescue節にいます"
+        # ログ7
+        logger.debug "⑦エラー, #{e}"
+
         render json: {
           session: false,
           user: {}


### PR DESCRIPTION
## 関連するissue
- ref  #334 

## 概要
 oauthsコントローラにデバッグのロジックを追加した
 
## 確認事項
 oauthsコントローラにデバッグのロジックが追加されている

## 確認方法
差分ファイルから確認できます。

## 懸念点
特になし。

## 参考記事
特になし。
